### PR TITLE
feat: add open source contribution guidelines

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+TFY_BASE_URL=https://your-org.truefoundry.cloud
+TFY_API_KEY=tfy-...
+TFY_CLUSTER_ID=your-cluster-id

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,49 @@ jobs:
           bash scripts/install.sh --help > /tmp/install_help.txt
           test -s /tmp/install_help.txt
 
-      - name: Install script end-to-end test (Codex target)
+  install-e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - agent: claude
+            config_dir: .claude
+            skills_dir: .claude/skills
+          - agent: cursor
+            config_dir: .cursor
+            skills_dir: .cursor/skills
+          - agent: codex
+            config_dir: .codex
+            skills_dir: .codex/skills
+          - agent: opencode
+            config_dir: .config/opencode
+            skills_dir: .config/opencode/skill
+          - agent: windsurf
+            config_dir: .windsurf
+            skills_dir: .windsurf/skills
+          - agent: cline
+            config_dir: .cline
+            skills_dir: .cline/skills
+          - agent: roo-code
+            config_dir: .roo-code
+            skills_dir: .roo-code/skills
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install script end-to-end test (${{ matrix.agent }})
         run: |
           export HOME="$(mktemp -d)"
-          mkdir -p "$HOME/.codex"
-          bash scripts/install.sh --global --agents codex > /tmp/install_run.txt
-          test -d "$HOME/.codex/skills"
-          skill_count=$(find "$HOME/.codex/skills" -mindepth 1 -maxdepth 1 -type d -name 'truefoundry-*' | wc -l | tr -d ' ')
+          mkdir -p "$HOME/${{ matrix.config_dir }}"
+          bash scripts/install.sh --global --agents "${{ matrix.agent }}" > /tmp/install_run_${{ matrix.agent }}.txt
+
+          target_dir="$HOME/${{ matrix.skills_dir }}"
+          test -d "$target_dir"
+
+          skill_count=$(find "$target_dir" -mindepth 1 -maxdepth 1 -type d -name 'truefoundry-*' | wc -l | tr -d ' ')
           expected_count=$(find "$PWD/skills" -mindepth 1 -maxdepth 1 -type d -not -name '_*' | wc -l | tr -d ' ')
           test "$skill_count" = "$expected_count"
-          test -L "$HOME/.codex/skills/truefoundry-status/scripts"
-          test -L "$HOME/.codex/skills/truefoundry-status/references"
-          test -x "$HOME/.codex/skills/_shared/scripts/tfy-api.sh"
+
+          test -L "$target_dir/truefoundry-status/scripts"
+          test -L "$target_dir/truefoundry-status/references"
+          test -x "$target_dir/_shared/scripts/tfy-api.sh"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,7 @@ Before submitting a PR:
 - **Never auto-pick `TFY_WORKSPACE_FQN`** — always ask the user
 - **Keep decision logic inline** in skills — only extract lookup tables and boilerplate to shared refs
 - **Don't hardcode environment-specific values** in examples — use placeholders or env vars
+- **Never commit secrets** (`.env`, API keys, tokens) — use `.env.example` placeholders only
 - **Both MCP and API paths** must be documented in every skill that makes API calls
 
 ## Questions?

--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ export TFY_BASE_URL="https://your-org.truefoundry.cloud"
 export TFY_API_KEY="tfy-..."
 ```
 
+Keep secrets local only. Do not commit `.env` or API keys to Git.
+
 Restart your agent, then ask things like *"deploy my FastAPI app"*, *"show logs for my-service"*, or *"what's deployed?"*
+
+Example workflow:
+1. Ask: `is truefoundry connected?` (uses `status`)
+2. Ask: `what workspaces are available?` (uses `workspaces`)
+3. Ask: `show logs for my-service` (uses `logs`)
 
 ## Skills
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,7 +9,9 @@ set -euo pipefail
 
 REPO="truefoundry/tfy-agent-skills"
 BRANCH="main"
-TARBALL_URL="https://github.com/$REPO/archive/refs/heads/$BRANCH.tar.gz"
+DEFAULT_REF="$BRANCH"
+SOURCE_REF="${TFY_SKILLS_REF:-$DEFAULT_REF}"
+EXPECTED_SHA256="${TFY_SKILLS_SHA256:-}"
 
 # ── Colours ──────────────────────────────────────────────────────────────────
 BOLD=$'\033[1m'  DIM=$'\033[2m'
@@ -57,23 +59,33 @@ SHARED_REFS=( "references/api-endpoints.md" "references/deploy-template.py" "ref
 # ── Parse args ───────────────────────────────────────────────────────────────
 MODE=""            # "" = auto (global + local if applicable), "global", "local"
 FILTER_AGENTS=""   # comma-separated agent names to restrict to
+REF_SET_BY_ARG=0
+SHA_SET_BY_ARG=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --global) MODE="global"; shift ;;
     --local)  MODE="local";  shift ;;
     --agents) FILTER_AGENTS="$2"; shift 2 ;;
+    --ref) SOURCE_REF="$2"; REF_SET_BY_ARG=1; shift 2 ;;
+    --sha256) EXPECTED_SHA256="$2"; SHA_SET_BY_ARG=1; shift 2 ;;
     --help|-h)
       cat <<EOF
-Usage: install.sh [--global] [--local] [--agents claude,cursor,codex]
+Usage: install.sh [--global] [--local] [--agents claude,cursor,codex] [--ref REF] [--sha256 SHA256]
 
 Options:
   --global         Install to ~/.{agent}/skills/ only
   --local          Install to ./{agent}/skills/ in current directory only
   --agents LIST    Comma-separated agent names: claude,cursor,codex,opencode,windsurf,cline,roo-code
+  --ref REF        Git ref to install from (branch, tag, or commit SHA)
+  --sha256 HASH    Verify downloaded tarball SHA256 before extraction
 
 Without flags, installs globally to all detected agents,
 plus locally if agent config dirs exist in the current directory.
+
+Environment:
+  TFY_SKILLS_REF     Default ref when --ref is not provided (default: $DEFAULT_REF)
+  TFY_SKILLS_SHA256  Expected tarball SHA256 when --sha256 is not provided
 EOF
       exit 0 ;;
     *) error "Unknown option: $1"; exit 1 ;;
@@ -87,6 +99,37 @@ agent_allowed() {
   echo ",$FILTER_AGENTS," | grep -qi ",$name,"
 }
 
+sha256_of_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print tolower($1)}'
+    return 0
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print tolower($1)}'
+    return 0
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$file" | sed -E 's/^.*= //' | tr '[:upper:]' '[:lower:]'
+    return 0
+  fi
+  return 1
+}
+
+download_to_file() {
+  local url="$1"
+  local output_file="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$output_file"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$output_file" "$url"
+  else
+    error "Neither curl nor wget found. Install one and retry."
+    exit 1
+  fi
+}
+
 # ── Download source ──────────────────────────────────────────────────────────
 get_source() {
   # If running from inside the repo, use local files
@@ -96,6 +139,9 @@ get_source() {
     local repo_root
     repo_root="$(cd "$script_dir/.." 2>/dev/null && pwd)" || true
     if [ -d "$repo_root/skills/_shared" ]; then
+      if [ "$REF_SET_BY_ARG" -eq 1 ] || [ "$SHA_SET_BY_ARG" -eq 1 ] || [ -n "${TFY_SKILLS_REF:-}" ] || [ -n "${TFY_SKILLS_SHA256:-}" ]; then
+        warn "Using local repo source; --ref/--sha256 and TFY_SKILLS_REF/TFY_SKILLS_SHA256 are ignored."
+      fi
       info "Installing from local repo: ${CYAN}$repo_root${NC}" >&2
       echo "$repo_root"
       return 0
@@ -103,21 +149,34 @@ get_source() {
   fi
 
   # Download tarball (no git required)
-  info "Downloading from ${CYAN}github.com/$REPO${NC}..."
+  local tarball_url="https://codeload.github.com/$REPO/tar.gz/$SOURCE_REF"
+  info "Downloading ${CYAN}$REPO${NC} ref ${CYAN}$SOURCE_REF${NC}..."
   local tmpdir
   tmpdir=$(mktemp -d)
   trap 'rm -rf "$tmpdir"' EXIT
 
-  if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$TARBALL_URL" | tar xz -C "$tmpdir"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -qO- "$TARBALL_URL" | tar xz -C "$tmpdir"
-  else
-    error "Neither curl nor wget found. Install one and retry."
-    exit 1
+  local tarball="$tmpdir/source.tar.gz"
+  download_to_file "$tarball_url" "$tarball"
+
+  if [ -n "$EXPECTED_SHA256" ]; then
+    local actual_sha256 expected_sha256
+    expected_sha256="$(printf '%s' "$EXPECTED_SHA256" | tr '[:upper:]' '[:lower:]')"
+    if ! actual_sha256="$(sha256_of_file "$tarball")"; then
+      error "No SHA256 tool found (need sha256sum, shasum, or openssl) for verification."
+      exit 1
+    fi
+    if [ "$actual_sha256" != "$expected_sha256" ]; then
+      error "SHA256 mismatch for downloaded tarball."
+      error "Expected: $expected_sha256"
+      error "Actual:   $actual_sha256"
+      exit 1
+    fi
+    ok "SHA256 verified."
   fi
 
-  # GitHub tarballs extract to {repo}-{branch}/
+  tar xz -f "$tarball" -C "$tmpdir"
+
+  # GitHub tarballs extract to a single top-level directory.
   local extracted
   extracted=$(find "$tmpdir" -mindepth 1 -maxdepth 1 -type d | head -1)
   if [ -z "$extracted" ] || [ ! -d "$extracted/skills" ]; then

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -20,10 +20,51 @@ require_file_contains() {
   fi
 }
 
+get_frontmatter_block() {
+  local file="$1"
+  awk '
+    $0 == "---" {
+      delimiter_count++
+      if (delimiter_count == 1) {
+        next
+      }
+      if (delimiter_count == 2) {
+        exit
+      }
+    }
+    delimiter_count == 1 {
+      print
+    }
+  ' "$file"
+}
+
 get_frontmatter_value() {
   local file="$1"
   local key="$2"
-  sed -n '1,/^---$/p' "$file" | grep -m1 "^${key}:" | sed "s/^${key}:[[:space:]]*//"
+  get_frontmatter_block "$file" | awk -v key="$key" '
+    $0 ~ "^[[:space:]]*" key ":[[:space:]]*" {
+      sub("^[[:space:]]*" key ":[[:space:]]*", "", $0)
+      print
+      exit
+    }
+  '
+}
+
+get_explicit_only_skills_from_agents() {
+  local agents_file="$1"
+  awk '
+    /The explicit-only skills are:/ {
+      line = $0
+      while (match(line, /`[^`]+`/)) {
+        skill = substr(line, RSTART + 1, RLENGTH - 2)
+        print skill
+        line = substr(line, RSTART + RLENGTH)
+      }
+      exit
+    }
+  ' "$agents_file" \
+    | sort \
+    | paste -sd' ' -
 }
 
 echo "Validating skill frontmatter..."
@@ -61,13 +102,16 @@ done < <(find "$SKILLS_DIR" -mindepth 2 -maxdepth 2 -name SKILL.md | sort)
 
 echo "Validating disable-model-invocation policy..."
 
-expected_disabled="async-service deploy helm llm-deploy multi-service"
+expected_disabled="$(get_explicit_only_skills_from_agents "$REPO_ROOT/AGENTS.md")"
+if [[ -z "$expected_disabled" ]]; then
+  fail "could not parse explicit-only skills from AGENTS.md"
+fi
+
 actual_disabled="$({
   for skill_md in "$SKILLS_DIR"/*/SKILL.md; do
-    # Check both legacy top-level field and current metadata nested field
-    frontmatter="$(sed -n '1,/^---$/p' "$skill_md")"
-    if echo "$frontmatter" | grep -q '^disable-model-invocation:[[:space:]]*true$' || \
-       echo "$frontmatter" | grep -q 'disable-model-invocation:[[:space:]]*"true"'; then
+    # Check both legacy top-level field and current metadata nested field.
+    frontmatter="$(get_frontmatter_block "$skill_md")"
+    if echo "$frontmatter" | grep -Eq "^[[:space:]]*disable-model-invocation:[[:space:]]*(true|\"true\"|'true')([[:space:]]*#.*)?$"; then
       basename "$(dirname "$skill_md")"
     fi
   done
@@ -99,7 +143,7 @@ echo "Validating docs consistency..."
 
 # Verify all three docs mention the explicit-only skills
 for doc in README.md AGENTS.md CLAUDE.md; do
-  for skill in deploy helm llm-deploy async-service multi-service; do
+  for skill in $expected_disabled; do
     if ! grep -q "$skill" "$REPO_ROOT/$doc"; then
       fail "$doc does not mention explicit-only skill: $skill"
     fi


### PR DESCRIPTION
## What changed?

- Add 2 new skills: service-test and preferences                                                            
  - Extract oversized skills into 18 reference files; all skills now under 500 lines                          
  - Add license: MIT and compatibility fields to all skills (agentskills.io spec)
  - Harden tfy-api.sh — safe .env parser, scrub internal values, fix command injection in hook
  - Add OSS governance: CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CODEOWNERS, issue/PR templates
  - Strengthen CI: shellcheck, skill validation, install E2E test
  - Remove example apps, rewrite README

## Checklist

- [x] Ran `./scripts/sync-shared.sh` (if shared files were edited)
- [x] Ran `./scripts/install.sh` and tested locally
- [ ] All SKILL.md files have valid frontmatter (name, description, license, compatibility)
- [x] No hardcoded credentials, internal URLs, or private values
- [ ] New skills include both MCP and direct API instructions
