### PR TITLE
fix: address 10 deploy skill issues from user testing

### DIFF
--- a/skills/_shared/references/cli-fallback.md
+++ b/skills/_shared/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/_shared/references/cluster-discovery.md
+++ b/skills/_shared/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/_shared/references/manifest-defaults.md
+++ b/skills/_shared/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/_shared/references/manifest-schema.md
+++ b/skills/_shared/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/_shared/references/prerequisites.md
+++ b/skills/_shared/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/_shared/scripts/tfy-api.sh
+++ b/skills/_shared/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/access-tokens/references/cli-fallback.md
+++ b/skills/access-tokens/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/access-tokens/references/cluster-discovery.md
+++ b/skills/access-tokens/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/access-tokens/references/manifest-defaults.md
+++ b/skills/access-tokens/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/access-tokens/references/manifest-schema.md
+++ b/skills/access-tokens/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/access-tokens/references/prerequisites.md
+++ b/skills/access-tokens/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/access-tokens/scripts/tfy-api.sh
+++ b/skills/access-tokens/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/ai-gateway/references/cli-fallback.md
+++ b/skills/ai-gateway/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/ai-gateway/references/cluster-discovery.md
+++ b/skills/ai-gateway/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/ai-gateway/references/manifest-defaults.md
+++ b/skills/ai-gateway/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/ai-gateway/references/manifest-schema.md
+++ b/skills/ai-gateway/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/ai-gateway/references/prerequisites.md
+++ b/skills/ai-gateway/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/ai-gateway/scripts/tfy-api.sh
+++ b/skills/ai-gateway/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/applications/references/cli-fallback.md
+++ b/skills/applications/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/applications/references/cluster-discovery.md
+++ b/skills/applications/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/applications/references/manifest-defaults.md
+++ b/skills/applications/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/applications/references/manifest-schema.md
+++ b/skills/applications/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/applications/references/prerequisites.md
+++ b/skills/applications/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/applications/scripts/tfy-api.sh
+++ b/skills/applications/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/async-service/references/cli-fallback.md
+++ b/skills/async-service/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/async-service/references/cluster-discovery.md
+++ b/skills/async-service/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/async-service/references/manifest-defaults.md
+++ b/skills/async-service/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/async-service/references/manifest-schema.md
+++ b/skills/async-service/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/async-service/references/prerequisites.md
+++ b/skills/async-service/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/async-service/scripts/tfy-api.sh
+++ b/skills/async-service/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -5,19 +5,20 @@ license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance
 metadata:
   disable-model-invocation: "true"
-allowed-tools: Bash(tfy*) Bash(*/tfy-api.sh *) Bash(*/tfy-version.sh *) Bash(docker *)
+allowed-tools: Bash(tfy*) Bash(*/tfy-api.sh *) Bash(*/tfy-version.sh *) Bash(docker *) Bash(tfy deploy*)
 ---
 
 <objective>
 
 # Deploy to TrueFoundry
 
-Deploy code or images to TrueFoundry. Two paths:
+Deploy code or images to TrueFoundry. Three paths:
 
-1. **CLI** (`tfy apply`) — Write a YAML manifest and apply it. Works everywhere.
-2. **REST API** (fallback) — When CLI unavailable, use `tfy-api.sh`.
+1. **CLI: `tfy apply`** — For pre-built Docker images. Write a YAML manifest and apply it.
+2. **CLI: `tfy deploy`** — For local code or git sources (builds remotely). Write a YAML manifest and deploy.
+3. **REST API** (fallback) — When CLI unavailable, use `tfy-api.sh`.
 
-Use the CLI path by default. Fall back to REST API only if `tfy` CLI is not installed and the user cannot install it.
+Use the CLI path by default. Use `tfy apply` for pre-built images, `tfy deploy` for build sources. Fall back to REST API only if `tfy` CLI is not installed and the user cannot install it.
 
 ## When to Use
 
@@ -44,30 +45,25 @@ Use the CLI path by default. Fall back to REST API only if `tfy` CLI is not inst
 
 For credential check commands and .env setup, see `references/prerequisites.md`.
 
-## Choose Deployment Path
+## Step 0: Scan Environment & Ask Key Questions
 
-**Default to CLI (`tfy apply`).** Only use REST API if CLI is unavailable.
+### 0a. Discover All TFY Variables
 
-| User's situation | Path |
-|---|---|
-| Has a pre-built Docker image | YAML manifest + `tfy apply` |
-| Code is in a Git repo | YAML manifest with git build source + `tfy apply` |
-| Code is local-only, has Docker | Docker build locally -> YAML manifest with image + `tfy apply` |
-| Code is local-only, no Docker | Push code to Git first -> YAML manifest with git build |
-| Has existing manifest.yaml | `tfy apply -f manifest.yaml` directly |
+**FIRST action before anything else** — scan `.env` and environment for all TFY-prefixed variables:
 
-### Detection Steps
+```bash
+# Discover all TFY-prefixed variables from .env
+grep '^TFY_' .env 2>/dev/null || true
 
-1. Check: Is the `tfy` CLI installed? (`tfy --version`)
-   - If not: `pip install truefoundry` to install it
-2. Check: Is the code in a Git repository? (`git remote -v`) -> If yes, use YAML manifest with Git build
-3. Ask: "Do you have a pre-built Docker image?" -> If yes, use YAML manifest with image
-4. If local code only: check for `docker` -> Docker build + YAML manifest with image
-5. Otherwise -> suggest pushing code to Git first, then YAML manifest with git build
+# Check environment
+env | grep '^TFY_' 2>/dev/null || true
+```
 
-## Step 0: Detect Environment
+Use discovered values to skip unnecessary API calls and pre-fill questions below.
 
-**Before anything else**, check what tools are available:
+> **WARNING:** Never use `source .env`. The `tfy-api.sh` script handles `.env` parsing automatically with proper quote-stripping. For shell access to individual values, use: `grep KEY .env | cut -d= -f2-`
+
+### 0b. Detect Tools
 
 ```bash
 # Check for CLI
@@ -77,16 +73,63 @@ tfy --version 2>/dev/null
 git remote -v 2>/dev/null
 
 # Check for existing manifest
-ls tfy-manifest.yaml 2>/dev/null
+ls tfy-manifest.yaml truefoundry.yaml 2>/dev/null
 
 # Check for Docker (only matters for local build path)
 docker --version 2>/dev/null
+
+# Get current branch (for git-based deploys)
+git branch --show-current 2>/dev/null
 ```
 
 If `tfy` CLI is not installed:
 ```bash
 pip install truefoundry
 ```
+
+### 0c. Ask Workspace (Mandatory)
+
+**Never skip this. Never auto-pick.**
+
+1. Check if `TFY_WORKSPACE_FQN` was found in `.env` or environment (from step 0a)
+2. If found: **confirm** with the user — "I found workspace `X` — deploy there?"
+3. If not found: **ask** — "Which workspace should I deploy to? (format: `cluster:workspace`)"
+4. Only if the user doesn't know their workspace, THEN list workspaces using the `workspaces` skill
+
+### 0d. Ask Deployment Source (Mandatory)
+
+**Never auto-decide the deployment strategy.** Always ask:
+
+```
+How do you want to deploy?
+1. Local code (upload from this machine) — DEFAULT
+2. Git repo (TrueFoundry pulls from GitHub/GitLab)
+3. Pre-built Docker image (already in a registry)
+```
+
+Then ask about build method:
+```
+How should the image be built?
+1. Use existing Dockerfile — DEFAULT (if Dockerfile detected)
+2. Create a Dockerfile (I'll help write one)
+3. Use buildpack (no Dockerfile needed, Python only)
+```
+
+Use environment checks (git remote, Dockerfile presence) as **context to inform suggestions**, but never auto-decide.
+
+## Choose Deployment Command
+
+**Critical:** The CLI command depends on the image source type. See `references/cli-fallback.md` for details.
+
+| Situation | Command | Manifest file |
+|---|---|---|
+| Pre-built Docker image | `tfy apply -f tfy-manifest.yaml` | `tfy-manifest.yaml` |
+| Local code + Dockerfile | `tfy deploy -f truefoundry.yaml --no-wait` | `truefoundry.yaml` |
+| Git source + Dockerfile | `tfy deploy -f truefoundry.yaml --no-wait` | `truefoundry.yaml` |
+| Git source + Buildpack | `tfy deploy -f truefoundry.yaml --no-wait` | `truefoundry.yaml` |
+| Has existing manifest | Check `image.type` → use appropriate command above |
+
+> **`tfy apply` does NOT support `build_source`.** Using it with git/local sources fails with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
 
 </context>
 
@@ -231,19 +274,34 @@ Write the manifest to `tfy-manifest.yaml` in the project directory.
 
 ### Step 3: Preview
 
+For pre-built images (`image.type: image`):
 ```bash
 tfy apply -f tfy-manifest.yaml --dry-run --show-diff
 ```
 
+For build sources (`image.type: build`):
+```bash
+# tfy deploy does not support --dry-run; review the manifest manually
+cat truefoundry.yaml
+```
+
 Show the preview output to the user. If this is an update to an existing service, the diff shows what will change.
 
-### Step 4: Apply
+### Step 4: Deploy
 
-After user confirms:
+After user confirms, use the appropriate command based on image type:
 
+**Pre-built image** (`image.type: image`):
 ```bash
 tfy apply -f tfy-manifest.yaml
 ```
+
+**Build source** (`image.type: build` — local or git):
+```bash
+tfy deploy -f truefoundry.yaml --no-wait
+```
+
+> **Do NOT use `tfy apply` with build sources.** It will fail with "must match exactly one schema in oneOf". See `references/cli-fallback.md` for details.
 
 ### Fallback: REST API
 
@@ -253,11 +311,13 @@ If `tfy` CLI is not available, convert the YAML manifest to JSON and deploy via 
 TFY_API_SH=~/.claude/skills/truefoundry-deploy/scripts/tfy-api.sh
 
 # Get workspace ID from FQN
-$TFY_API_SH GET "/api/svc/v1/workspaces?fqn=${TFY_WORKSPACE_FQN}"
+bash $TFY_API_SH GET "/api/svc/v1/workspaces?fqn=${TFY_WORKSPACE_FQN}"
 
 # Deploy via REST API (JSON body)
-$TFY_API_SH PUT /api/svc/v1/apps '{ "manifest": { ... }, "workspaceId": "WORKSPACE_ID" }'
+bash $TFY_API_SH PUT /api/svc/v1/apps '{ "manifest": { ... }, "workspaceId": "WORKSPACE_ID" }'
 ```
+
+> **Note:** Use `bash $TFY_API_SH` instead of `$TFY_API_SH` directly to avoid "permission denied" errors if the script lacks execute permissions.
 
 ## User Confirmation Checklist
 
@@ -265,6 +325,7 @@ $TFY_API_SH PUT /api/svc/v1/apps '{ "manifest": { ... }, "workspaceId": "WORKSPA
 
 - [ ] **Service name** -- what to call this deployment
 - [ ] **Image source** -- pre-built image, Git repo + Dockerfile, Git repo + PythonBuild, or local Docker build?
+- [ ] **Branch** (if git source) -- which branch to build from? Default to current branch (`git branch --show-current`), never hardcode `main`
 - [ ] **Port** -- what port the application listens on
 - [ ] **Expected load** -- TPS, concurrent users, environment (dev/staging/prod) -> use Step 2 analysis
 - [ ] **CPU/Memory** -- show resource suggestion table from Step 2 (defaults vs suggested values)

--- a/skills/deploy/references/cli-fallback.md
+++ b/skills/deploy/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/deploy/references/cluster-discovery.md
+++ b/skills/deploy/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/deploy/references/deploy-errors.md
+++ b/skills/deploy/references/deploy-errors.md
@@ -90,6 +90,54 @@ No Dockerfile found. Options:
        command: uvicorn main:app --host 0.0.0.0 --port 8000
 ```
 
+## `tfy apply` Fails with "must match exactly one schema in oneOf"
+
+```
+This error occurs when using `tfy apply` with a build_source (git or local).
+`tfy apply` only supports pre-built images (image.type: image).
+
+Fix: Use `tfy deploy -f truefoundry.yaml --no-wait` for source-based deployments.
+This is the most common deploy skill mistake — always check the image type before
+choosing the command.
+```
+
+## `tfy apply` Fails with Missing `ref` Field
+
+```
+If git build_source is rejected for missing a `ref` field, this is another reason
+to prefer `tfy deploy -f` for source-based deployments. `tfy deploy` handles
+git refs automatically. If you must use `tfy apply`, add a `ref` field to
+build_source with the commit SHA or tag.
+```
+
+## Cluster API Returns 403 Forbidden
+
+```
+The user's API key does not have permission to access the cluster API.
+Fallback steps:
+1. Check .env for TFY_CLUSTER_FQN
+2. List existing apps in the workspace and extract domain from ports[].host
+3. Ask the user for the base domain directly
+4. For internal-only services, skip domain discovery (set expose: false)
+See references/cluster-discovery.md for details.
+```
+
+## Replicas Format Rejected
+
+```
+If `replicas: { min: N, max: M }` is rejected, try block-style YAML:
+
+replicas:
+  min: 2
+  max: 5
+
+Or fall back to a fixed integer:
+
+replicas: 2
+
+Some tfy CLI versions may not accept inline object notation for replicas.
+```
+
 ## REST API Fallback Errors
 
 ### 401 Unauthorized

--- a/skills/deploy/references/manifest-defaults.md
+++ b/skills/deploy/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/deploy/references/manifest-schema.md
+++ b/skills/deploy/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/deploy/references/prerequisites.md
+++ b/skills/deploy/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/deploy/scripts/tfy-api.sh
+++ b/skills/deploy/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/docs/references/cli-fallback.md
+++ b/skills/docs/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/docs/references/cluster-discovery.md
+++ b/skills/docs/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/docs/references/manifest-defaults.md
+++ b/skills/docs/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/docs/references/manifest-schema.md
+++ b/skills/docs/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/docs/references/prerequisites.md
+++ b/skills/docs/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/docs/scripts/tfy-api.sh
+++ b/skills/docs/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/gitops/references/cli-fallback.md
+++ b/skills/gitops/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/gitops/references/cluster-discovery.md
+++ b/skills/gitops/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/gitops/references/manifest-defaults.md
+++ b/skills/gitops/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/gitops/references/manifest-schema.md
+++ b/skills/gitops/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/gitops/references/prerequisites.md
+++ b/skills/gitops/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/gitops/scripts/tfy-api.sh
+++ b/skills/gitops/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/helm/references/cli-fallback.md
+++ b/skills/helm/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/helm/references/cluster-discovery.md
+++ b/skills/helm/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/helm/references/manifest-defaults.md
+++ b/skills/helm/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/helm/references/manifest-schema.md
+++ b/skills/helm/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/helm/references/prerequisites.md
+++ b/skills/helm/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/helm/scripts/tfy-api.sh
+++ b/skills/helm/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/jobs/references/cli-fallback.md
+++ b/skills/jobs/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/jobs/references/cluster-discovery.md
+++ b/skills/jobs/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/jobs/references/manifest-defaults.md
+++ b/skills/jobs/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/jobs/references/manifest-schema.md
+++ b/skills/jobs/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/jobs/references/prerequisites.md
+++ b/skills/jobs/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/jobs/scripts/tfy-api.sh
+++ b/skills/jobs/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/llm-deploy/references/cli-fallback.md
+++ b/skills/llm-deploy/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/llm-deploy/references/cluster-discovery.md
+++ b/skills/llm-deploy/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/llm-deploy/references/manifest-defaults.md
+++ b/skills/llm-deploy/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/llm-deploy/references/manifest-schema.md
+++ b/skills/llm-deploy/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/llm-deploy/references/prerequisites.md
+++ b/skills/llm-deploy/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/llm-deploy/scripts/tfy-api.sh
+++ b/skills/llm-deploy/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/logs/references/cli-fallback.md
+++ b/skills/logs/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/logs/references/cluster-discovery.md
+++ b/skills/logs/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/logs/references/manifest-defaults.md
+++ b/skills/logs/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/logs/references/manifest-schema.md
+++ b/skills/logs/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/logs/references/prerequisites.md
+++ b/skills/logs/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/logs/scripts/tfy-api.sh
+++ b/skills/logs/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/ml-repos/references/cli-fallback.md
+++ b/skills/ml-repos/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/ml-repos/references/cluster-discovery.md
+++ b/skills/ml-repos/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/ml-repos/references/manifest-defaults.md
+++ b/skills/ml-repos/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/ml-repos/references/manifest-schema.md
+++ b/skills/ml-repos/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/ml-repos/references/prerequisites.md
+++ b/skills/ml-repos/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/ml-repos/scripts/tfy-api.sh
+++ b/skills/ml-repos/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/multi-service/references/cli-fallback.md
+++ b/skills/multi-service/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/multi-service/references/cluster-discovery.md
+++ b/skills/multi-service/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/multi-service/references/manifest-defaults.md
+++ b/skills/multi-service/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/multi-service/references/manifest-schema.md
+++ b/skills/multi-service/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/multi-service/references/prerequisites.md
+++ b/skills/multi-service/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/multi-service/scripts/tfy-api.sh
+++ b/skills/multi-service/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/notebooks/references/cli-fallback.md
+++ b/skills/notebooks/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/notebooks/references/cluster-discovery.md
+++ b/skills/notebooks/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/notebooks/references/manifest-defaults.md
+++ b/skills/notebooks/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/notebooks/references/manifest-schema.md
+++ b/skills/notebooks/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/notebooks/references/prerequisites.md
+++ b/skills/notebooks/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/notebooks/scripts/tfy-api.sh
+++ b/skills/notebooks/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/preferences/references/cli-fallback.md
+++ b/skills/preferences/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/preferences/references/cluster-discovery.md
+++ b/skills/preferences/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/preferences/references/manifest-defaults.md
+++ b/skills/preferences/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/preferences/references/manifest-schema.md
+++ b/skills/preferences/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/preferences/references/prerequisites.md
+++ b/skills/preferences/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/preferences/scripts/tfy-api.sh
+++ b/skills/preferences/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/prompts/references/cli-fallback.md
+++ b/skills/prompts/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/prompts/references/cluster-discovery.md
+++ b/skills/prompts/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/prompts/references/manifest-defaults.md
+++ b/skills/prompts/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/prompts/references/manifest-schema.md
+++ b/skills/prompts/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/prompts/references/prerequisites.md
+++ b/skills/prompts/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/prompts/scripts/tfy-api.sh
+++ b/skills/prompts/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/secrets/references/cli-fallback.md
+++ b/skills/secrets/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/secrets/references/cluster-discovery.md
+++ b/skills/secrets/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/secrets/references/manifest-defaults.md
+++ b/skills/secrets/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/secrets/references/manifest-schema.md
+++ b/skills/secrets/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/secrets/references/prerequisites.md
+++ b/skills/secrets/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/secrets/scripts/tfy-api.sh
+++ b/skills/secrets/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/service-test/references/cli-fallback.md
+++ b/skills/service-test/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/service-test/references/cluster-discovery.md
+++ b/skills/service-test/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/service-test/references/manifest-defaults.md
+++ b/skills/service-test/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/service-test/references/manifest-schema.md
+++ b/skills/service-test/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/service-test/references/prerequisites.md
+++ b/skills/service-test/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/service-test/scripts/tfy-api.sh
+++ b/skills/service-test/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/ssh-server/references/cli-fallback.md
+++ b/skills/ssh-server/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/ssh-server/references/cluster-discovery.md
+++ b/skills/ssh-server/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/ssh-server/references/manifest-defaults.md
+++ b/skills/ssh-server/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/ssh-server/references/manifest-schema.md
+++ b/skills/ssh-server/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/ssh-server/references/prerequisites.md
+++ b/skills/ssh-server/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/ssh-server/scripts/tfy-api.sh
+++ b/skills/ssh-server/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/status/references/cli-fallback.md
+++ b/skills/status/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/status/references/cluster-discovery.md
+++ b/skills/status/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/status/references/manifest-defaults.md
+++ b/skills/status/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/status/references/manifest-schema.md
+++ b/skills/status/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/status/references/prerequisites.md
+++ b/skills/status/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/status/scripts/tfy-api.sh
+++ b/skills/status/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/tfy-apply/references/cli-fallback.md
+++ b/skills/tfy-apply/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/tfy-apply/references/cluster-discovery.md
+++ b/skills/tfy-apply/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/tfy-apply/references/manifest-defaults.md
+++ b/skills/tfy-apply/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/tfy-apply/references/manifest-schema.md
+++ b/skills/tfy-apply/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/tfy-apply/references/prerequisites.md
+++ b/skills/tfy-apply/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/tfy-apply/scripts/tfy-api.sh
+++ b/skills/tfy-apply/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/tracing/references/cli-fallback.md
+++ b/skills/tracing/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/tracing/references/cluster-discovery.md
+++ b/skills/tracing/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/tracing/references/manifest-defaults.md
+++ b/skills/tracing/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/tracing/references/manifest-schema.md
+++ b/skills/tracing/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/tracing/references/prerequisites.md
+++ b/skills/tracing/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/tracing/scripts/tfy-api.sh
+++ b/skills/tracing/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/volumes/references/cli-fallback.md
+++ b/skills/volumes/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/volumes/references/cluster-discovery.md
+++ b/skills/volumes/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/volumes/references/manifest-defaults.md
+++ b/skills/volumes/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/volumes/references/manifest-schema.md
+++ b/skills/volumes/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/volumes/references/prerequisites.md
+++ b/skills/volumes/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/volumes/scripts/tfy-api.sh
+++ b/skills/volumes/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/workflows/references/cli-fallback.md
+++ b/skills/workflows/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/workflows/references/cluster-discovery.md
+++ b/skills/workflows/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/workflows/references/manifest-defaults.md
+++ b/skills/workflows/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/workflows/references/manifest-schema.md
+++ b/skills/workflows/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/workflows/references/prerequisites.md
+++ b/skills/workflows/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/workflows/scripts/tfy-api.sh
+++ b/skills/workflows/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1

--- a/skills/workspaces/references/cli-fallback.md
+++ b/skills/workspaces/references/cli-fallback.md
@@ -83,6 +83,29 @@ tfy login --host "$TFY_BASE_URL"
 tfy login --host "$TFY_BASE_URL" --api-key "$TFY_API_KEY"
 ```
 
+## `tfy apply` vs `tfy deploy`
+
+**Critical:** `tfy apply` only supports `image.type: image` (pre-built images). For build sources (local code or git), use `tfy deploy`.
+
+| Situation | Command |
+|---|---|
+| Pre-built Docker image (`type: image`) | `tfy apply -f manifest.yaml` |
+| Local code + Dockerfile (`type: build`, `build_source.type: local`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Dockerfile (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+| Git source + Buildpack (`type: build`, `build_source.type: git`) | `tfy deploy -f truefoundry.yaml --no-wait` |
+
+> **Note:** `tfy apply` with a `build_source` will fail with "must match exactly one schema in oneOf". Always use `tfy deploy -f` for source-based deployments.
+
+### `tfy deploy` Usage
+
+```bash
+# Deploy from local source or git (builds remotely on TrueFoundry)
+tfy deploy -f truefoundry.yaml --no-wait
+
+# The manifest file is typically named truefoundry.yaml for tfy deploy
+# It uses the same schema as tfy apply manifests
+```
+
 ## Decision Flowchart
 
 ```

--- a/skills/workspaces/references/cluster-discovery.md
+++ b/skills/workspaces/references/cluster-discovery.md
@@ -31,6 +31,19 @@ $TFY_API_SH GET /api/svc/v1/clusters/CLUSTER_ID
 
 The cluster API shows what GPU types are available. Only present available types to the user.
 
+## Fallback: When Cluster API Returns 403
+
+If the cluster API returns 403 Forbidden or is otherwise unavailable:
+
+1. **Check `.env` for `TFY_CLUSTER_FQN`** — may already have the cluster info
+2. **List existing apps in the workspace** and extract domain patterns from `ports[].host`:
+   ```bash
+   $TFY_API_SH GET "/api/svc/v1/apps?workspaceFqn=${TFY_WORKSPACE_FQN}&limit=5"
+   # Look at ports[].host in any existing app to infer the base domain
+   ```
+3. **Ask the user directly** — "What's your cluster's base domain? (e.g., `ml.your-org.truefoundry.cloud`)"
+4. **For internal-only services**, skip domain discovery entirely — set `expose: false` and omit `host`
+
 ## Storage Class Reference
 
 | Provider | Storage Class | Type | Notes |

--- a/skills/workspaces/references/manifest-defaults.md
+++ b/skills/workspaces/references/manifest-defaults.md
@@ -81,7 +81,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -119,7 +119,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: tfy-python-buildpack
     build_context_path: ./
@@ -415,7 +415,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -455,7 +455,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -497,7 +497,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile
@@ -538,7 +538,7 @@ image:
   build_source:
     type: git
     repo_url: ${REPO_URL}
-    branch_name: ${BRANCH:-main}
+    branch_name: ${BRANCH}  # Use current branch: git branch --show-current
   build_spec:
     type: dockerfile
     dockerfile_path: Dockerfile

--- a/skills/workspaces/references/manifest-schema.md
+++ b/skills/workspaces/references/manifest-schema.md
@@ -638,7 +638,8 @@ image:
 |-------|------|----------|-------------|
 | `type` | string | Yes | `git` or `local` |
 | `repo_url` | string | Yes (git) | Git repository URL |
-| `branch_name` | string | No (git) | Branch or ref to build from (default: `main`) |
+| `branch_name` | string | No (git) | Branch to build from. Default: current branch (`git branch --show-current`). |
+| `ref` | string | No (git) | Git ref (commit SHA, tag). May be required by `tfy apply` for git sources. |
 | `project_root_path` | string | Yes (local) | Path to local project root |
 
 ### BuildSpec

--- a/skills/workspaces/references/prerequisites.md
+++ b/skills/workspaces/references/prerequisites.md
@@ -35,6 +35,17 @@ echo "TFY_WORKSPACE_FQN: ${TFY_WORKSPACE_FQN:-(not set)}"
 | `TFY_WORKSPACE_FQN` | For deploys | Workspace fully qualified name (e.g., `cluster-id:workspace-name`) |
 | `TFY_CLUSTER_ID` | Optional | Cluster ID — auto-extracted from workspace FQN if not set |
 
+### Variable Name Aliases
+
+Different tools use different variable names. The `tfy-api.sh` script auto-resolves these:
+
+| Canonical (used by scripts) | Alias (CLI) | Alias (.env files) | Notes |
+|---|---|---|---|
+| `TFY_BASE_URL` | `TFY_HOST` | `TFY_API_HOST` | `tfy-api.sh` checks all three in order |
+| `TFY_API_KEY` | -- | -- | Same name everywhere |
+
+If your `.env` uses `TFY_HOST` or `TFY_API_HOST`, the scripts will pick it up automatically. No manual renaming needed.
+
 ## Workspace FQN Rule
 
 **Never auto-pick a workspace.** Always ask the user.

--- a/skills/workspaces/scripts/tfy-api.sh
+++ b/skills/workspaces/scripts/tfy-api.sh
@@ -31,6 +31,9 @@ if [[ -f ".env" ]]; then
   done < .env
 fi
 
+# Resolve common aliases (TFY_HOST used by CLI, TFY_API_HOST used by some .env files)
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
 if [[ -z "${TFY_BASE_URL:-}" ]]; then
   echo '{"error": "TFY_BASE_URL not set. Export it or add to .env"}' >&2
   exit 1


### PR DESCRIPTION
- Ask workspace upfront (confirm from .env or prompt user) instead of listing all
- Always ask deployment source (local/git/image) instead of auto-detecting
- Distinguish tfy apply (images only) vs tfy deploy (build sources)
- Default branch to current branch instead of hardcoding main
- Auto-resolve TFY_BASE_URL/TFY_HOST/TFY_API_HOST env var aliases
- Warn against source .env; script handles .env parsing safely
- Add cluster API 403 fallback (check .env, inspect existing apps, ask user)
- Use bash $TFY_API_SH pattern to avoid permission denied errors
- Document ref field in BuildSource schema for tfy apply compatibility
- Scan .env for all TFY_ variables as first action before deploying
- Add replicas format troubleshooting note

## What changed?

Brief description of the changes.

## Checklist

- [x] Ran `./scripts/sync-shared.sh` (if shared files were edited)
- [x] Ran `./scripts/install.sh` and tested locally
- [x] All SKILL.md files have valid frontmatter (name, description, license, compatibility)
- [x] No hardcoded credentials, internal URLs, or private values
- [x] New skills include both MCP and direct API instructions
