### PR TITLE
docs: clarify README onboarding and default gateway install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ Works with Claude Code, Cursor, Codex, OpenCode, Windsurf, Cline, and Roo Code.
 
 ## Install
 
+Install Gateway skills (default track):
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/truefoundry/tfy-agent-skills/main/scripts/install.sh | bash
 ```
 
-This installs **Gateway** skills (the default track). To install a different track:
+To install a different track:
 
 ```bash
 # Deploy skills (infrastructure, apps, jobs, etc.)
@@ -23,7 +25,9 @@ curl -fsSL https://raw.githubusercontent.com/truefoundry/tfy-agent-skills/main/s
 curl -fsSL https://raw.githubusercontent.com/truefoundry/tfy-agent-skills/main/scripts/install.sh | bash -s -- all
 ```
 
-Restart your agent and start asking. If credentials are not set, your agent will prompt for them. You can also pre-set them via env vars or a `.env` file in your project root:
+Restart your agent and start asking.
+
+If credentials are not set, your agent will prompt for them. You can also pre-set them via env vars or a `.env` file in your project root:
 
 ```bash
 export TFY_BASE_URL=https://your-org.truefoundry.cloud
@@ -33,13 +37,7 @@ export TFY_API_KEY=tfy-...  # https://docs.truefoundry.com/docs/generate-api-key
 
 Do not commit `.env` files or API keys to Git.
 
-If you do not have a TrueFoundry account yet, sign up first with:
-
-```bash
-uv run tfy register
-```
-
-`tfy register` is interactive. Depending on the registration server configuration, it may open a browser window for CAPTCHA or other human verification before asking you to finish email verification. After registration completes, open the tenant URL returned by the CLI, create a personal access token there, and then set `TFY_API_KEY` for the skills that use the platform API.
+If you do not have a TrueFoundry account yet, complete signup first, verify your email, open your tenant URL, create a personal access token, and then set `TFY_API_KEY` for the skills that use the platform API.
 
 ## Product Tracks
 
@@ -99,7 +97,7 @@ No SDKs to learn, no code to write. Your agent handles everything.
 ./scripts/setup-git-hooks.sh
 
 # Install a product track and restart
-./scripts/install.sh gateway
+./scripts/install.sh
 ./scripts/install.sh deploy
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed?

Updated `README.md` to simplify onboarding and make Gateway installation clearly default. Removed the `uv run tfy register` command and replaced it with neutral signup guidance.

## Before / After

**Before:**
- README included a dedicated `uv run tfy register` command block and long interactive flow details.
- Gateway default wording existed but was less explicit in install examples.
- Local install examples used explicit `gateway` argument.

**After:**
- Removed `tfy register` command and its detailed CLI-specific flow.
- Added concise account setup guidance: signup, verify email, open tenant URL, create PAT, set `TFY_API_KEY`.
- Clarified install section with `Install Gateway skills (default track):`.
- Updated development/local install example to use `./scripts/install.sh` as default gateway path.
- Ran `./scripts/validate-skills.sh` successfully.

## Checklist

- [ ] Tested locally with `./scripts/install.sh`
- [x] Ran `./scripts/validate-skills.sh`
- [x] No hardcoded credentials or private URLs
- [ ] Ran `./scripts/sync-shared.sh` (if shared files were edited)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://truefoundryworkspace.slack.com/archives/C0AF68U6ZL4/p1774594896036599?thread_ts=1774594896.036599&cid=C0AF68U6ZL4)

<div><a href="https://cursor.com/agents/bc-92086b4f-0333-4cda-bd96-1aff64ccb50b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92086b4f-0333-4cda-bd96-1aff64ccb50b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

