### PR TITLE
feat: namespace gateway skills with truefoundry prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ Markdown skill files that let AI coding agents configure and manage the [TrueFou
 ## Install
 
 ```bash
-npx skills add truefoundry/tfy-gateway-skills
+npx skills add truefoundry/tfy-gateway-skills --all
 ```
+
+`--all` installs all skills for all agents without interactive selection prompts.
 
 Or via curl:
 
@@ -36,6 +38,8 @@ New to TrueFoundry? Run `uv run tfy register` to sign up interactively.
 | **Platform** | [access-control](skills/access-control), [access-tokens](skills/access-tokens), [docs](skills/docs), [logs](skills/logs), [onboarding](skills/onboarding), [secrets](skills/secrets), [status](skills/status), [tracing](skills/tracing), [workspaces](skills/workspaces) |
 
 Just ask your agent in plain English — it picks the right skill automatically.
+
+Installed skill names are namespaced as `truefoundry-<skill>` (for example, `truefoundry-ai-gateway`) to avoid collisions with generic skill names.
 
 ## Development
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,6 +47,7 @@ AGENTS_GLOBAL=(
   ".roo-code|.roo-code/skills|Roo Code"
 )
 
+# All skill source directories in this repo.
 SKILL_NAMES=(
   access-control access-tokens agents ai-gateway ai-monitoring docs guardrails integrations logs mcp-servers onboarding prompts secrets status tracing workspaces
 )

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -69,8 +69,9 @@ while IFS= read -r skill_md; do
   [[ -n "$description" ]] || fail "$skill_md missing frontmatter field: description"
   [[ -n "$allowed_tools" ]] || fail "$skill_md missing frontmatter field: allowed-tools"
 
-  if [[ "$name" != "$skill_dir" ]]; then
-    fail "$skill_md name '$name' must match directory '$skill_dir'"
+  expected_name="truefoundry-$skill_dir"
+  if [[ "$name" != "$expected_name" ]]; then
+    fail "$skill_md name '$name' must match expected '$expected_name'"
   fi
 
   if ! [[ "$name" =~ ^[a-z0-9-]+$ ]]; then

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: access-control
+name: truefoundry-access-control
 description: Manages TrueFoundry roles, teams, and collaborators. Create custom roles, organize users into teams, and grant access to resources. Use when managing permissions, creating teams, or adding collaborators.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/access-tokens/SKILL.md
+++ b/skills/access-tokens/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: access-tokens
+name: truefoundry-access-tokens
 description: Manages TrueFoundry personal access tokens (PATs). List, create, and delete tokens for API auth, CI/CD, and gateway access.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/agents/SKILL.md
+++ b/skills/agents/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: agents
+name: truefoundry-agents
 description: Manages TrueFoundry Agent Registry. List, create, update, and delete AI agents with prompt-backed sources, collaborator access, and sample inputs.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/ai-gateway/SKILL.md
+++ b/skills/ai-gateway/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ai-gateway
+name: truefoundry-ai-gateway
 description: Configures TrueFoundry AI Gateway for unified OpenAI-compatible LLM access. Covers auth (PAT/VAT), model routing, rate limiting, and budget controls.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/ai-monitoring/SKILL.md
+++ b/skills/ai-monitoring/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ai-monitoring
+name: truefoundry-ai-monitoring
 description: Monitors AI Gateway traffic, costs, latency, errors, and token usage by querying request traces via the spans query API.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: docs
+name: truefoundry-docs
 description: Fetches TrueFoundry documentation, API reference, and deployment guides. Use when the user needs platform docs or how-to guidance.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/guardrails/SKILL.md
+++ b/skills/guardrails/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: guardrails
+name: truefoundry-guardrails
 description: Configures content safety guardrails for TrueFoundry AI Gateway. Supports PII filtering, content moderation, prompt injection detection, and custom rules. Use when adding safety controls to LLM or MCP tool calls.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/integrations/SKILL.md
+++ b/skills/integrations/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: integrations
+name: truefoundry-integrations
 description: Manages TrueFoundry LLM provider account integrations. Add, list, and manage providers (OpenAI, AWS Bedrock, Google Vertex, Azure, Groq, Together AI, self-hosted models, etc.).
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/logs/SKILL.md
+++ b/skills/logs/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: logs
+name: truefoundry-logs
 description: Views, downloads, and searches application and job logs from TrueFoundry. Supports time-range filtering, pod filtering, and error search.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/mcp-servers/SKILL.md
+++ b/skills/mcp-servers/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mcp-servers
+name: truefoundry-mcp-servers
 description: Registers MCP servers with TrueFoundry for discovery and access control. Supports remote servers, virtual (composite) servers, and OpenAPI-to-MCP wrapping. Use when adding, listing, or managing MCP server registrations.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/onboarding/SKILL.md
+++ b/skills/onboarding/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: onboarding
+name: truefoundry-onboarding
 description: Guides new users through TrueFoundry setup — account registration, email verification, credential configuration, and first deployment. Use when the user says "get started", "set up truefoundry", "new account", "register", "onboard", "I'm new", or has no credentials configured.
 license: MIT
 compatibility: Requires Bash, curl, and Python (uv or pip)

--- a/skills/prompts/SKILL.md
+++ b/skills/prompts/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: prompts
+name: truefoundry-prompts
 description: Manages TrueFoundry prompt registry prompts and versions. Handles listing, creating, updating, deleting, and tagging prompt versions.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: secrets
+name: truefoundry-secrets
 description: Manages TrueFoundry secret groups and secrets. Handles listing, creating, updating, and deleting secret groups and individual key-value secrets.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: status
+name: truefoundry-status
 description: Checks TrueFoundry connection status and verifies credentials (TFY_BASE_URL/TFY_HOST, TFY_API_KEY). Used as a preflight check before any TrueFoundry operation.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/tracing/SKILL.md
+++ b/skills/tracing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tracing
+name: truefoundry-tracing
 description: Adds OpenTelemetry-based tracing to applications via TrueFoundry's tracing platform (Traceloop SDK). Creates tracing projects, instruments Python/TypeScript code, and captures LLM calls and custom spans.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance

--- a/skills/workspaces/SKILL.md
+++ b/skills/workspaces/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: workspaces
+name: truefoundry-workspaces
 description: Lists TrueFoundry workspaces and clusters. Provides workspace FQNs for deployment, cluster connectivity status, available GPU types, and base domains.
 license: MIT
 compatibility: Requires Bash, curl, and access to a TrueFoundry instance


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed?

Namespaced all gateway skill frontmatter names with a `truefoundry-` prefix (matching the deploy-skills approach) and aligned validation/install docs so this convention is enforced and clearly documented.

## Before / After

**Before:**

- Skill frontmatter used generic names like `ai-gateway`, `status`, `workspaces`.
- Validator expected `name` to match directory directly.
- README install command used interactive `npx skills add` without `--all`.

**After:**

- All skills now use namespaced names like `truefoundry-ai-gateway`, `truefoundry-status`, `truefoundry-workspaces`.
- `scripts/validate-skills.sh` enforces `name: truefoundry-<directory>`.
- README now uses `npx skills add truefoundry/tfy-gateway-skills --all` and documents namespaced installed skill names.

Validation evidence:

- `./scripts/validate-skills.sh` ✅
- `./scripts/validate-skill-security.sh` ✅
- `./scripts/test-tfy-api.sh` ✅

## Checklist

- [ ] Tested locally with `./scripts/install.sh`
- [x] Ran `./scripts/validate-skills.sh`
- [x] No hardcoded credentials or private URLs
- [ ] Ran `./scripts/sync-shared.sh` (if shared files were edited)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://truefoundryworkspace.slack.com/archives/C0AF68U6ZL4/p1774913883718119?thread_ts=1774913883.718119&cid=C0AF68U6ZL4)

<div><a href="https://cursor.com/agents/bc-66c24acb-73fe-5da7-99cf-301437c60c14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66c24acb-73fe-5da7-99cf-301437c60c14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

