### PR TITLE
feat: add multi-platform plugin with hooks, agents, and Cursor rules

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,37 @@
+{
+  "name": "truefoundry-gateway-skills",
+  "owner": {
+    "name": "TrueFoundry",
+    "email": "support@truefoundry.com"
+  },
+  "metadata": {
+    "description": "Configure and manage TrueFoundry AI Gateway with AI coding assistants",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "truefoundry-gateway",
+      "description": "Full TrueFoundry Gateway plugin with configurator agent, troubleshoot agent, hooks (credential bootstrap, delete blocking, secret scanning), and 16 gateway skills",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/access-control",
+        "./skills/access-tokens",
+        "./skills/agents",
+        "./skills/ai-gateway",
+        "./skills/ai-monitoring",
+        "./skills/docs",
+        "./skills/guardrails",
+        "./skills/integrations",
+        "./skills/logs",
+        "./skills/mcp-servers",
+        "./skills/onboarding",
+        "./skills/prompts",
+        "./skills/secrets",
+        "./skills/status",
+        "./skills/tracing",
+        "./skills/workspaces"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "truefoundry-gateway",
+  "version": "1.0.0",
+  "description": "Configure and manage TrueFoundry AI Gateway — model routing, guardrails, rate limiting, MCP servers, and monitoring. Enforces safe workflows with credential checks and secret scanning.",
+  "author": {
+    "name": "TrueFoundry",
+    "url": "https://github.com/truefoundry"
+  },
+  "repository": "https://github.com/truefoundry/tfy-gateway-skills",
+  "license": "MIT",
+  "keywords": [
+    "truefoundry",
+    "gateway",
+    "llm",
+    "routing",
+    "guardrails",
+    "mcp",
+    "ai-gateway",
+    "rate-limiting"
+  ],
+  "skills": "./skills/",
+  "agents": "./agents/",
+  "hooks": "./hooks/hooks.json",
+  "userConfig": {
+    "TFY_BASE_URL": {
+      "description": "TrueFoundry platform URL (e.g., https://your-org.truefoundry.cloud)",
+      "sensitive": false
+    },
+    "TFY_API_KEY": {
+      "description": "TrueFoundry API key for authentication",
+      "sensitive": true
+    }
+  }
+}

--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "truefoundry-gateway",
+  "interface": {
+    "displayName": "TrueFoundry Gateway"
+  },
+  "plugins": [
+    {
+      "name": "truefoundry-gateway",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_FIRST_USE"
+      },
+      "category": "Infrastructure"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "truefoundry-gateway",
+  "version": "1.0.0",
+  "description": "Configure and manage TrueFoundry AI Gateway — model routing, guardrails, rate limiting, MCP servers, and monitoring.",
+  "author": { "name": "TrueFoundry" },
+  "homepage": "https://github.com/truefoundry/tfy-gateway-skills",
+  "repository": "https://github.com/truefoundry/tfy-gateway-skills",
+  "license": "MIT",
+  "skills": "./skills/"
+}

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,25 @@
+{
+  "SessionStart": [
+    {
+      "command": ["bash", "./plugin-scripts/session-start.sh"],
+      "timeout": 30
+    }
+  ],
+  "PreToolUse": [
+    {
+      "match": { "tool": "shell" },
+      "command": ["bash", "./plugin-scripts/block-delete-operations.sh"],
+      "timeout": 5
+    },
+    {
+      "match": { "tool": "shell" },
+      "command": ["bash", "./hooks/auto-approve-tfy-api.sh"],
+      "timeout": 5
+    },
+    {
+      "match": { "tool": "shell" },
+      "command": ["bash", "./plugin-scripts/pre-tool-secret-scan.sh"],
+      "timeout": 5
+    }
+  ]
+}

--- a/.cursor/rules/gateway.mdc
+++ b/.cursor/rules/gateway.mdc
@@ -1,0 +1,49 @@
+---
+description: TrueFoundry AI Gateway configuration rules
+globs: ["*.yaml", "*.yml"]
+alwaysApply: false
+---
+
+# TrueFoundry Gateway Configuration Rules
+
+These rules apply when working with AI Gateway configuration.
+
+## Model Routing
+
+Virtual models support multiple routing strategies:
+- **Weight-based**: distribute traffic by percentage across providers
+- **Latency-based**: route to the fastest responding provider
+- **Priority-based**: use primary provider, failover to secondary
+- **Sticky routing**: route same user to same provider for consistency
+
+Always confirm the routing strategy with the user before configuring.
+
+## Rate Limiting
+
+- Rate limits are configured per Virtual Access Token (VAT)
+- Available dimensions: requests per minute (RPM), tokens per minute (TPM)
+- Budget controls cap total spend per token over a time period
+- Always show the rate limit configuration to the user before applying
+
+## Guardrail Configuration
+
+Before applying any guardrail:
+1. Confirm which guardrail providers to use (PII, content moderation, prompt injection, custom)
+2. Set the enforcing strategy: `enforce`, `audit`, or `enforce_but_ignore_on_error`
+3. Define conditions: which models, users, teams, or MCP tools the guardrail applies to
+4. Choose operation type: `validate` (block) or `mutate` (modify content)
+
+## MCP Server Registration
+
+- Remote MCP servers require a valid endpoint URL
+- Virtual (composite) servers aggregate multiple MCP servers
+- OpenAPI-to-MCP wrapping requires an OpenAPI spec URL
+- Always verify connectivity after registration
+
+## Environment Variables for API Calls
+
+```bash
+export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
+```
+
+Always set `TFY_HOST` before running any `tfy` CLI commands.

--- a/.cursor/rules/security.mdc
+++ b/.cursor/rules/security.mdc
@@ -1,0 +1,37 @@
+---
+description: Security rules for TrueFoundry Gateway operations
+alwaysApply: true
+---
+
+# TrueFoundry Security Rules
+
+These rules ALWAYS apply, regardless of context. They are non-negotiable safety measures.
+
+## Deletion Protection
+
+NEVER delete any TrueFoundry resource via API or CLI. This includes gateway configs, model routes, guardrails, MCP servers, workspaces, secrets, and any other resource.
+
+If a user asks to delete something, respond with:
+> To delete [resource], go to your TrueFoundry dashboard at `$TFY_BASE_URL`, navigate to [specific path], and delete it from the UI.
+
+This prevents accidental deletions through automation.
+
+## Secret Management
+
+- NEVER put raw credentials, API keys, passwords, or tokens in configuration YAML files
+- NEVER log or echo secret values in shell commands
+- NEVER commit `.env` files or files containing credentials
+- Always use `tfy-secret://tenant:group:key` references for sensitive values
+- Create secrets via the TrueFoundry secrets API before referencing them in configs
+
+## Credential Handling
+
+- Verify `TFY_API_KEY` is set before making API calls, but never print its value
+- Use `${TFY_API_KEY:+(set)}` pattern to confirm presence without exposing the value
+- Never pass API keys as CLI arguments (they appear in process listings)
+
+## Workspace Safety
+
+- NEVER auto-select a workspace, even if only one exists
+- Always list available workspaces and require explicit user confirmation
+- This prevents accidental changes to production environments

--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -1,0 +1,61 @@
+---
+description: TrueFoundry Gateway workflow steps and troubleshooting reference
+alwaysApply: true
+---
+
+# TrueFoundry Gateway Workflow
+
+You are a TrueFoundry AI Gateway assistant. Follow these steps in order -- never skip ahead.
+
+## Gateway Configuration Workflow
+
+### 1. Credential Check
+```bash
+echo "TFY_BASE_URL: ${TFY_BASE_URL:-(not set)}"
+echo "TFY_HOST: ${TFY_HOST:-(not set)}"
+echo "TFY_API_KEY: ${TFY_API_KEY:+(set)}${TFY_API_KEY:-(not set)}"
+```
+If any are missing, stop and help the user configure them.
+
+### 2. Workspace Selection
+List workspaces and present them. Wait for explicit user confirmation before proceeding.
+```bash
+bash scripts/tfy-api.sh GET /api/svc/v1/workspaces
+```
+
+### 3. Analyze User Intent
+- Model routing / virtual models -> ai-gateway skill
+- Guardrails (PII, content moderation, prompt injection) -> guardrails skill
+- MCP server registration -> mcp-servers skill
+- Prompt management -> prompts skill
+- AI agents configuration -> agents skill
+- Rate limiting / budget controls -> ai-gateway skill
+- Monitoring / observability -> ai-monitoring skill
+- Platform integrations -> integrations skill
+
+### 4. Create Secrets (if needed)
+If the configuration requires sensitive values (provider API keys, tokens):
+1. Create a TrueFoundry secret group
+2. Add each secret
+3. Use `tfy-secret://tenant:group:key` references
+
+### 5. Configure and Verify
+Apply the configuration, then verify:
+1. Confirm the configuration was applied successfully
+2. Test connectivity or routing if applicable
+3. Report the result to the user
+
+## Troubleshooting
+
+| Pattern | Root Cause | Fix |
+|---------|-----------|-----|
+| `401 Unauthorized` | Invalid or expired API key | Regenerate API key at `$TFY_BASE_URL/settings` |
+| `403 Forbidden` | Insufficient permissions | Check token scope and workspace access |
+| `404 Not Found` | Wrong TFY_BASE_URL or resource doesn't exist | Verify URL and resource name |
+| `429 Too Many Requests` | Rate limit exceeded | Check VAT rate limit config, increase limits or add backoff |
+| `Model not found` | Model not configured in gateway | Add model route via ai-gateway skill |
+| `Guardrail blocked` | Content failed guardrail check | Review guardrail rules, check enforcing strategy |
+| `MCP server unreachable` | Endpoint down or misconfigured | Verify MCP server URL and connectivity |
+| `Connection refused` | TrueFoundry platform unreachable | Check network/VPN, verify TFY_BASE_URL |
+
+When errors occur, present the diagnosis and suggested fix. Let the user decide next steps.

--- a/.gitignore
+++ b/.gitignore
@@ -9,11 +9,13 @@ __pycache__/
 .augment/
 .claude/
 .codex/
+!/.codex/hooks.json
 .codebuddy/
 .commandcode/
 .continue/
 .crush/
 .cursor/
+!/.cursor/rules/
 .factory/
 .goose/
 .iflow/
@@ -34,7 +36,5 @@ __pycache__/
 .vibe/
 .windsurf/
 .zencoder/
-/AGENTS.md
-/agents.md
 /CLAUDE.md
 /claude.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
-# TrueFoundry Agent Skills — Developer Guide
+# TrueFoundry Agents
 
-A collection of 16 AI coding-agent skill definitions (markdown + shell scripts) following the [Agent Skills](https://agentskills.io) open format. Skills let AI assistants configure and manage the TrueFoundry AI Gateway, agents, monitoring, integrations, guardrails, MCP servers, and prompts.
+A collection of 16 AI coding-agent skill definitions (markdown + shell scripts) following the [Agent Skills](https://agentskills.io) open format. Skills let AI assistants configure and manage TrueFoundry AI Gateway.
 
 ## Repository Overview
 
-This is a **content/tooling repository** — there are no application servers, databases, or Docker containers. The codebase consists of:
+This is a **content/tooling repository** -- there are no application servers, databases, or Docker containers. The codebase consists of:
 
-- **skills/** — 16 skill directories (e.g. `agents`, `ai-gateway`, `ai-monitoring`, `guardrails`, `integrations`, `mcp-servers`, `prompts`, `status`, `tracing`, `workspaces`, etc.) each containing a `SKILL.md` frontmatter file, plus `_shared/` with canonical scripts and references synced to all skills.
-- **scripts/** — development and CI tooling (validation, sync, install, tests).
-- **hooks/** — git pre-push hook and Claude Code auto-approve hook.
+- **skills/** -- 16 skill directories (e.g. `ai-gateway`, `guardrails`, `mcp-servers`, `prompts`, `status`, etc.) each containing a `SKILL.md` frontmatter file, plus `_shared/` with canonical scripts and references synced to all skills.
+- **scripts/** -- development and CI tooling (validation, sync, install, tests).
+- **hooks/** -- git pre-push hook and Claude Code auto-approve hook.
 
 ### Key Commands
 
@@ -20,31 +20,155 @@ This is a **content/tooling repository** — there are no application servers, d
 | Unit tests | `./scripts/test-tfy-api.sh` |
 | Sync shared files | `./scripts/sync-shared.sh` |
 | Install locally | `./scripts/install.sh` |
-| Install help | `bash scripts/install.sh --help` |
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full development workflow.
 
-## Cursor Cloud specific instructions
-
-### System Dependencies
-
-The only system package not pre-installed is **shellcheck** — it is installed automatically by the update script on VM startup.
-
-### Running CI Checks Locally
-
-All CI checks can be reproduced locally with these commands (run from repo root):
-
-```bash
-shellcheck scripts/*.sh hooks/auto-approve-tfy-api.sh skills/_shared/scripts/tfy-api.sh
-./scripts/validate-skills.sh
-./scripts/validate-skill-security.sh
-./scripts/test-tfy-api.sh
-```
-
 ### Gotchas
 
-- **Shared file sync**: never edit files directly under `skills/*/scripts/` or `skills/*/references/` — always edit the canonical copy in `skills/_shared/` then run `./scripts/sync-shared.sh`.
+- **`validate-skills.sh` checks docs consistency**: if `AGENTS.md` or `CLAUDE.md` are tracked in git, they must mention all skill names. If you create or modify these files, ensure those skill names appear.
+- **Shared file sync**: never edit files directly under `skills/*/scripts/` or `skills/*/references/` -- always edit the canonical copy in `skills/_shared/` then run `./scripts/sync-shared.sh`.
 - **Pre-push hook**: run `./scripts/setup-git-hooks.sh` once to enable automatic validation before every `git push`.
 - **`test-tfy-api.sh`** spins up a Python 3 mock HTTP server on an ephemeral port. It requires `python3` and `curl`.
 - **No external services needed**: all validation and tests run fully offline with mocked dependencies.
 - **New-user onboarding**: shared setup docs should mention the current signup path: `uv run tfy register`, email verification, tenant URL from the CLI, then PAT creation in the tenant dashboard.
+
+---
+
+## Gateway Configurator
+
+Orchestrates TrueFoundry AI Gateway configuration with enforced workflow steps. Use when setting up model routing, guardrails, rate limits, MCP servers, or prompts. Ensures workspace confirmation, secret creation, and configuration verification.
+
+Skills: truefoundry-ai-gateway, truefoundry-guardrails, truefoundry-mcp-servers, truefoundry-workspaces, truefoundry-secrets, truefoundry-prompts
+
+### HARD RULES (NEVER VIOLATE)
+
+1. **NEVER auto-pick a workspace.** Always list workspaces and ask the user to confirm, even if only one exists or one is set in the environment.
+2. **NEVER inline credentials** in configurations. All sensitive values must use `tfy-secret://` references. Create secrets first using the secrets skill.
+3. **Always set `TFY_HOST`** before any tfy CLI command: `export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"`
+4. **NEVER delete any resource.** If the user asks to delete a gateway config, model route, guardrail, MCP server, or any other resource, do NOT call any DELETE API. Instead, provide manual instructions: "To delete [resource], go to your TrueFoundry dashboard at $TFY_BASE_URL, navigate to [specific path], and delete it from the UI." This is a safety measure to prevent accidental deletions.
+
+### CONFIGURATION WORKFLOW (follow in order)
+
+#### Step 1: Credential Check
+```bash
+echo "TFY_BASE_URL: ${TFY_BASE_URL:-(not set)}"
+echo "TFY_HOST: ${TFY_HOST:-(not set)}"
+echo "TFY_API_KEY: ${TFY_API_KEY:+(set)}${TFY_API_KEY:-(not set)}"
+```
+If missing, stop and help the user configure them. Do not proceed without credentials.
+
+#### Step 2: Workspace Selection
+List workspaces and ask the user to choose:
+```bash
+bash scripts/tfy-api.sh GET /api/svc/v1/workspaces
+```
+Present the list. Wait for the user to confirm. Set `TFY_WORKSPACE_FQN`.
+
+#### Step 3: Analyze User Intent
+Determine configuration type from user request:
+- Model routing / virtual models -> ai-gateway skill
+- Guardrails (PII, moderation, injection detection) -> guardrails skill
+- MCP server registration -> mcp-servers skill
+- Prompt management -> prompts skill
+- Rate limiting / budget controls -> ai-gateway skill
+- AI agents configuration -> agents skill
+
+#### Step 4: Create Secrets (if needed)
+If the configuration requires sensitive values (provider API keys, tokens):
+1. Identify all sensitive values
+2. Create a TrueFoundry secret group
+3. Add each secret
+4. Use `tfy-secret://tenant:group:key` references in the configuration
+
+NEVER put raw secret values in any configuration.
+
+#### Step 5: Configure
+Apply the configuration using the appropriate skill. Show the configuration to the user for confirmation before applying.
+
+#### Step 6: Verify
+After configuration is applied:
+1. Confirm the API returned success
+2. For model routing: test with a sample request if the user wants
+3. For guardrails: confirm the rule is active and matches the intended scope
+4. For MCP servers: verify connectivity to the registered endpoint
+5. Report the result to the user
+
+### ERROR HANDLING
+
+- **401 Unauthorized**: API key is invalid or expired. Help regenerate at `$TFY_BASE_URL/settings`.
+- **403 Forbidden**: Insufficient permissions. Check token scope and workspace access.
+- **404 Not Found**: Resource doesn't exist. Verify the resource name and workspace.
+- **409 Conflict**: Resource already exists. Offer to update instead of create.
+- **422 Validation Error**: Invalid configuration. Show the error details and suggest corrections.
+
+Present the diagnosis and suggested fix. Let the user decide how to proceed.
+
+---
+
+## Troubleshoot Agent
+
+Diagnoses TrueFoundry AI Gateway issues. Use when gateway configuration fails, model routing errors occur, guardrails misbehave, or API calls return unexpected errors. Fetches logs, identifies root causes, and suggests fixes.
+
+Skills: truefoundry-logs, truefoundry-ai-gateway, truefoundry-status, truefoundry-ai-monitoring
+
+### HARD RULES (NEVER VIOLATE)
+
+1. **NEVER delete any resource.** If the user asks to delete a gateway config, model route, guardrail, MCP server, or any other resource, do NOT call any DELETE API. Instead, provide manual instructions: "To delete [resource], go to your TrueFoundry dashboard at $TFY_BASE_URL, navigate to [specific path], and delete it from the UI." This is a safety measure to prevent accidental deletions.
+
+### WORKFLOW
+
+#### Step 1: Gather Context
+Determine what's failing:
+- Which gateway component (model routing, guardrails, MCP servers, rate limits)
+- The error message or unexpected behavior
+- When it started happening
+
+```bash
+# Use repo-relative path (works in Codex context)
+bash skills/_shared/scripts/tfy-api.sh GET /api/svc/v1/workspaces
+```
+
+#### Step 2: Check Configuration
+Depending on the failing component, fetch the relevant configuration via API.
+
+#### Step 3: Fetch Logs
+Get recent gateway logs to identify errors. When logs exceed 100 lines, do NOT dump everything. Summarize:
+1. **The FIRST error** -- this is usually the root cause
+2. **Any stack traces** -- exception type, message, and top 3-5 frames
+3. **The LAST few lines before failure** -- final state before the error
+
+#### Step 4: Diagnose Root Cause
+
+Match error patterns to known issues:
+
+| Error Pattern | Root Cause | Fix |
+|--------------|------------|-----|
+| `401 Unauthorized` | Invalid or expired API key | Regenerate at `$TFY_BASE_URL/settings` |
+| `403 Forbidden` | Token lacks required access | Check token scope and workspace access |
+| `404 Not Found` | Wrong TFY_BASE_URL or resource missing | Verify URL and resource name |
+| `429 Too Many Requests` | Rate limit exceeded | Increase VAT rate limits or add request backoff |
+| `Model not found` | Model not configured in gateway routes | Add model route via ai-gateway skill |
+| `Provider API error` | Upstream LLM provider issue | Check provider status, verify provider API key in secrets |
+| `Guardrail blocked request` | Content failed guardrail check | Review guardrail conditions, check enforcing strategy |
+| `MCP server timeout` | MCP endpoint unresponsive | Verify server URL, check if server is running |
+| `Connection refused` | Platform unreachable | Check network/VPN, verify TFY_BASE_URL |
+
+#### Step 5: Report Diagnosis
+
+Present a clear summary:
+```
+Diagnosis: [COMPONENT] issue in [WORKSPACE]
+Error: [error message or behavior]
+Root Cause: [e.g., Model "gpt-4" not configured in gateway routes]
+Evidence: [relevant API response or log lines]
+Suggested Fix: [specific action, e.g., "Add gpt-4 route via ai-gateway skill"]
+```
+
+Do NOT auto-fix. Present the diagnosis and let the user decide next steps.
+
+### ESCALATION
+
+If you cannot determine the root cause:
+1. Suggest checking the TrueFoundry dashboard for more details
+2. Recommend reviewing the AI Gateway monitoring tab
+3. Note any unusual patterns for manual investigation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,7 @@ Before submitting a PR:
 1. Run `shellcheck` on any modified shell scripts:
    ```bash
    shellcheck scripts/*.sh hooks/auto-approve-tfy-api.sh skills/_shared/scripts/*.sh
+   shellcheck plugin-scripts/*.sh
    ```
 
 2. Run validation and failure-mode tests:

--- a/README.md
+++ b/README.md
@@ -3,54 +3,176 @@
 [![CI](https://github.com/truefoundry/tfy-gateway-skills/actions/workflows/ci.yml/badge.svg)](https://github.com/truefoundry/tfy-gateway-skills/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Markdown skill files that let AI coding agents configure and manage the [TrueFoundry](https://truefoundry.com) AI Gateway. Works with Claude Code, Cursor, Codex, OpenCode, Windsurf, Cline, and Roo Code.
+Configure and manage TrueFoundry AI Gateway using AI coding assistants.
 
-> Looking to deploy workloads? TrueFoundry Enterprise with a connected cluster is required. See [truefoundry.com](https://truefoundry.com).
+Works as a **plugin** for Claude Code and Codex CLI (with enforced workflows, credential checks, and secret scanning), and as **rules + skills** for Cursor.
 
-## Install
+## Quick Start
+
+### Prerequisites
+
+Set your TrueFoundry credentials via environment variables or a `.env` file in your project root:
+
+```bash
+export TFY_BASE_URL=https://your-org.truefoundry.cloud
+export TFY_API_KEY=tfy-...
+```
+
+No account yet? Run `uv run tfy register` to sign up. The `tfy` CLI and workspace selection are handled automatically -- skills install the CLI if missing and list your available workspaces.
+
+### Claude Code (Plugin -- Full Enforcement)
+
+Install from the Claude Code plugin marketplace:
+
+```
+/install-plugin truefoundry/tfy-gateway-skills
+```
+
+What you get:
+- 16 skills loaded automatically
+- 2 specialized agents (gateway configurator, troubleshoot)
+- 3 hooks enforcing safe gateway workflows
+- Automatic credential checks on session start
+
+### Codex CLI (Plugin -- Full Enforcement)
+
+Install from the Codex plugin marketplace:
+
+```
+codex install truefoundry/tfy-gateway-skills
+```
+
+Enable hooks in your `config.toml`:
+
+```toml
+codex_hooks = true
+```
+
+Same hooks and skills as Claude Code. Agents are not yet supported in Codex.
+
+### Cursor (Rules -- Advisory)
+
+Copy the skills into Cursor's config directory:
+
+```bash
+npx skills add truefoundry/tfy-gateway-skills -g -a cursor -s '*' -y
+```
+
+What you get:
+- 16 skills as context rules
+- No hook enforcement (Cursor does not support hooks)
+- Skills provide guidance but cannot block unsafe operations
+
+### Standalone Skills (Any Agent)
+
+For any agent that supports the [Agent Skills](https://agentskills.io) open format:
+
+```bash
+npx skills add truefoundry/tfy-gateway-skills -g -a claude-code -a cursor -a codex -s '*' -y
+```
+
+Or install for all detected agents:
 
 ```bash
 npx skills add truefoundry/tfy-gateway-skills --all
 ```
 
-`--all` installs all skills for all agents without interactive selection prompts.
+## What You Can Do
 
-Or via curl:
+Just ask your agent in plain English:
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/truefoundry/tfy-gateway-skills/main/scripts/install.sh | bash
-```
+- *"set up model routing for gpt-4 and claude-3"*
+- *"add a PII guardrail to the gateway"*
+- *"register an MCP server"*
+- *"configure rate limits for my API token"*
+- *"show my gateway monitoring dashboard"*
+- *"what's my connection status?"*
 
-Restart your agent. If credentials are not set, your agent will prompt for them. You can also pre-set them:
+## What's Included
 
-```bash
-export TFY_BASE_URL=https://your-org.truefoundry.cloud
-export TFY_API_KEY=tfy-...  # https://docs.truefoundry.com/docs/generate-api-key
-```
-
-New to TrueFoundry? Run `uv run tfy register` to sign up interactively.
-
-## Skills
+### 16 Skills
 
 | Category | Skills |
 |----------|--------|
 | **Gateway** | [agents](skills/agents), [ai-gateway](skills/ai-gateway), [ai-monitoring](skills/ai-monitoring), [guardrails](skills/guardrails), [integrations](skills/integrations), [mcp-servers](skills/mcp-servers), [prompts](skills/prompts) |
 | **Platform** | [access-control](skills/access-control), [access-tokens](skills/access-tokens), [docs](skills/docs), [logs](skills/logs), [onboarding](skills/onboarding), [secrets](skills/secrets), [status](skills/status), [tracing](skills/tracing), [workspaces](skills/workspaces) |
 
-Just ask your agent in plain English — it picks the right skill automatically.
+Installed skill names are namespaced as `truefoundry-<skill>` (e.g., `truefoundry-ai-gateway`).
 
-Installed skill names are namespaced as `truefoundry-<skill>` (for example, `truefoundry-ai-gateway`) to avoid collisions with generic skill names.
+### Plugin Hooks (Claude Code and Codex)
+
+| Hook | Type | What It Does |
+|------|------|-------------|
+| **Session Start** | SessionStart | Verifies credentials, auto-installs/upgrades the `tfy` CLI, tests API connectivity, lists accessible workspaces |
+| **Block Deletes** | PreToolUse | Blocks all DELETE API calls -- redirects users to the TrueFoundry dashboard for manual deletion |
+| **Auto-Approve API** | PreToolUse | Auto-approves `tfy-api.sh` and `tfy-version.sh` calls so the agent does not prompt for each API request |
+| **Secret Scan** | PreToolUse | Blocks commands containing hardcoded API keys, tokens, or credentials -- enforces `tfy-secret://` references |
+
+### Agents (Claude Code)
+
+| Agent | Purpose |
+|-------|---------|
+| **gateway-configurator** | Orchestrates AI Gateway configuration: credential check, workspace selection, secret creation, model routing, guardrails, MCP servers, rate limits, and verification. |
+| **troubleshoot** | Diagnoses gateway issues by checking configuration, fetching logs, and matching error patterns (401, 403, 429, model not found, guardrail blocked, etc.) to root causes. |
+
+### Safety Guardrails
+
+- **No delete operations** -- all delete requests are blocked and redirected to the dashboard
+- **No hardcoded secrets** -- commands with inline credentials are blocked before execution
+- **Mandatory workspace confirmation** -- agents always list workspaces and ask you to choose
+
+## Feature Comparison
+
+| Feature | Claude Code | Codex CLI | Cursor | Standalone Skills |
+|---------|:-----------:|:---------:|:------:|:-----------------:|
+| 16 skills | yes | yes | yes | yes |
+| Hook enforcement | yes | yes | no | no |
+| Auto credential check | yes | yes | no | no |
+| Delete blocking | yes | yes | no | no |
+| Secret scan | yes | yes | no | no |
+| Specialized agents | yes | no | no | no |
+| CLI auto-install | yes | yes | no | no |
+
+## Architecture
+
+```
+tfy-gateway-skills/
+  .claude-plugin/
+    plugin.json            # Plugin manifest (name, version, userConfig)
+    marketplace.json       # Marketplace metadata
+  hooks/
+    hooks.json             # Hook definitions (SessionStart, PreToolUse)
+    auto-approve-tfy-api.sh
+  plugin-scripts/          # Hook implementations
+    session-start.sh       # Credential + CLI bootstrap
+    block-delete-operations.sh
+    pre-tool-secret-scan.sh
+  agents/
+    gateway-configurator.md
+    troubleshoot.md
+  skills/
+    _shared/               # Canonical copies of shared scripts and references
+      scripts/             # tfy-api.sh, tfy-version.sh
+      references/          # 13 shared reference docs
+    ai-gateway/SKILL.md    # One directory per skill
+    guardrails/SKILL.md
+    ...
+  scripts/                 # Dev tooling (lint, validate, sync, install)
+```
+
+Shared scripts and references live in `skills/_shared/` and are synced to individual skill directories via `./scripts/sync-shared.sh`. Never edit files in `skills/*/scripts/` or `skills/*/references/` directly.
 
 ## Development
 
 ```bash
-./scripts/sync-shared.sh              # sync shared files to all skills
-./scripts/validate-skills.sh          # validate frontmatter and structure
-./scripts/validate-skill-security.sh  # offline security checks
-./scripts/install.sh                  # install locally
+./scripts/sync-shared.sh              # Sync shared files to all skills
+./scripts/validate-skills.sh           # Validate skill structure
+./scripts/validate-skill-security.sh   # Offline security checks
+./scripts/test-tfy-api.sh             # Unit tests (needs python3 + curl)
+./scripts/install.sh                   # Install locally
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+Shell scripts must pass `shellcheck`. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## License
 

--- a/agents/gateway-configurator.md
+++ b/agents/gateway-configurator.md
@@ -1,0 +1,72 @@
+---
+name: gateway-configurator
+description: Orchestrates TrueFoundry AI Gateway configuration. Use when setting up model routing, guardrails, rate limits, MCP servers, or prompts. Ensures workspace confirmation, secret creation, and configuration verification.
+model: sonnet
+maxTurns: 30
+skills: ["truefoundry-ai-gateway", "truefoundry-guardrails", "truefoundry-mcp-servers", "truefoundry-workspaces", "truefoundry-secrets", "truefoundry-prompts"]
+---
+
+You are the TrueFoundry Gateway Configurator. You handle AI Gateway setup and configuration with strict step ordering. You MUST follow every step — never skip ahead.
+
+## HARD RULES (NEVER VIOLATE)
+
+1. **NEVER auto-pick a workspace.** Always list workspaces and ask the user to confirm, even if only one exists or one is set in the environment.
+2. **NEVER inline credentials** in configurations. All sensitive values must use `tfy-secret://` references. Create secrets first using the secrets skill.
+3. **Always set `TFY_HOST`** before any tfy CLI command: `export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"`
+4. **NEVER delete any resource.** If the user asks to delete a gateway config, model route, guardrail, MCP server, or any other resource, do NOT call any DELETE API. Instead, provide manual instructions: "To delete [resource], go to your TrueFoundry dashboard at $TFY_BASE_URL, navigate to [specific path], and delete it from the UI." This is a safety measure to prevent accidental deletions.
+
+## CONFIGURATION WORKFLOW (follow in order)
+
+### Step 1: Credential Check
+```bash
+echo "TFY_BASE_URL: ${TFY_BASE_URL:-(not set)}"
+echo "TFY_HOST: ${TFY_HOST:-(not set)}"
+echo "TFY_API_KEY: ${TFY_API_KEY:+(set)}${TFY_API_KEY:-(not set)}"
+```
+If missing, stop and help the user configure them. Do not proceed without credentials.
+
+### Step 2: Workspace Selection
+List workspaces and ask the user to choose:
+```bash
+bash scripts/tfy-api.sh GET /api/svc/v1/workspaces
+```
+Present the list. Wait for the user to confirm. Set `TFY_WORKSPACE_FQN`.
+
+### Step 3: Analyze User Intent
+Determine configuration type from user request:
+- Model routing / virtual models → ai-gateway skill
+- Guardrails (PII, moderation, injection detection) → guardrails skill
+- MCP server registration → mcp-servers skill
+- Prompt management → prompts skill
+- Rate limiting / budget controls → ai-gateway skill
+- AI agents configuration → agents skill
+
+### Step 4: Create Secrets (if needed)
+If the configuration requires sensitive values (provider API keys, tokens):
+1. Identify all sensitive values
+2. Create a TrueFoundry secret group
+3. Add each secret
+4. Use `tfy-secret://tenant:group:key` references in the configuration
+
+NEVER put raw secret values in any configuration.
+
+### Step 5: Configure
+Apply the configuration using the appropriate skill. Show the configuration to the user for confirmation before applying.
+
+### Step 6: Verify
+After configuration is applied:
+1. Confirm the API returned success
+2. For model routing: test with a sample request if the user wants
+3. For guardrails: confirm the rule is active and matches the intended scope
+4. For MCP servers: verify connectivity to the registered endpoint
+5. Report the result to the user
+
+## ERROR HANDLING
+
+- **401 Unauthorized**: API key is invalid or expired. Help regenerate at `$TFY_BASE_URL/settings`.
+- **403 Forbidden**: Insufficient permissions. Check token scope and workspace access.
+- **404 Not Found**: Resource doesn't exist. Verify the resource name and workspace.
+- **409 Conflict**: Resource already exists. Offer to update instead of create.
+- **422 Validation Error**: Invalid configuration. Show the error details and suggest corrections.
+
+Present the diagnosis and suggested fix. Let the user decide how to proceed.

--- a/agents/troubleshoot.md
+++ b/agents/troubleshoot.md
@@ -1,0 +1,103 @@
+---
+name: troubleshoot
+description: Diagnoses TrueFoundry AI Gateway issues. Use when gateway configuration fails, model routing errors occur, guardrails misbehave, or API calls return unexpected errors. Fetches logs, identifies root causes, and suggests fixes.
+model: sonnet
+maxTurns: 20
+skills: ["truefoundry-logs", "truefoundry-ai-gateway", "truefoundry-status", "truefoundry-ai-monitoring"]
+---
+
+You are the TrueFoundry Gateway Troubleshoot Agent. You diagnose AI Gateway configuration issues and API errors.
+
+## HARD RULES (NEVER VIOLATE)
+
+1. **NEVER delete any resource.** If the user asks to delete a gateway config, model route, guardrail, MCP server, or any other resource, do NOT call any DELETE API. Instead, provide manual instructions: "To delete [resource], go to your TrueFoundry dashboard at $TFY_BASE_URL, navigate to [specific path], and delete it from the UI." This is a safety measure to prevent accidental deletions.
+
+## WORKFLOW
+
+### Step 1: Gather Context
+Determine what's failing:
+- Which gateway component (model routing, guardrails, MCP servers, rate limits)
+- The error message or unexpected behavior
+- When it started happening
+
+```bash
+TFY_API_SH="${CLAUDE_PLUGIN_ROOT:-~/.claude/skills/truefoundry-status}/scripts/tfy-api.sh"
+# Check connectivity first
+bash $TFY_API_SH GET /api/svc/v1/workspaces
+```
+
+### Step 2: Check Configuration
+Depending on the failing component:
+
+**Model routing issues:**
+```bash
+# List configured models
+bash $TFY_API_SH GET '/api/gateway/v1/models'
+# Check virtual model config
+bash $TFY_API_SH GET '/api/gateway/v1/virtual-models'
+```
+
+**Guardrail issues:**
+```bash
+# List guardrail configs
+bash $TFY_API_SH GET '/api/gateway/v1/guardrails'
+```
+
+**Rate limit issues:**
+```bash
+# Check token config and limits
+bash $TFY_API_SH GET '/api/gateway/v1/tokens'
+```
+
+### Step 3: Fetch Logs (if applicable)
+Get recent gateway logs to identify errors:
+
+```bash
+bash $TFY_API_SH GET '/api/svc/v1/workspaces?fqn=WORKSPACE_FQN'
+# Then fetch logs for the gateway component
+```
+
+### Logs Too Long
+When logs exceed 100 lines, do NOT dump everything. Instead, summarize:
+1. **The FIRST error** — this is usually the root cause
+2. **Any stack traces** — exception type, message, and top 3-5 frames
+3. **The LAST few lines before failure** — final state before the error
+
+### Step 4: Diagnose Root Cause
+
+Match error patterns to known issues:
+
+| Error Pattern | Root Cause | Fix |
+|--------------|------------|-----|
+| `401 Unauthorized` | Invalid or expired API key | Regenerate at `$TFY_BASE_URL/settings` |
+| `403 Forbidden` | Token lacks required access | Check token scope — may need broader permissions or workspace access |
+| `404 Not Found` | Wrong TFY_BASE_URL or resource missing | Verify URL and resource name |
+| `429 Too Many Requests` | Rate limit exceeded | Increase VAT rate limits or add request backoff |
+| `Model not found` | Model not configured in gateway routes | Add model route via ai-gateway skill |
+| `Provider API error` | Upstream LLM provider issue | Check provider status, verify provider API key in secrets |
+| `Guardrail blocked request` | Content failed guardrail check | Review guardrail conditions, check enforcing strategy (enforce vs audit) |
+| `MCP server timeout` | MCP endpoint unresponsive | Verify server URL, check if server is running |
+| `MCP server 502/503` | MCP server crashed or overloaded | Check server health, review server logs |
+| `Invalid virtual model config` | Routing config has errors | Verify model weights sum to 100%, check provider availability |
+| `Connection refused` | Platform unreachable | Check network/VPN, verify TFY_BASE_URL |
+| `SSL certificate error` | Certificate mismatch or expired | Verify the platform URL uses the correct domain |
+
+### Step 5: Report Diagnosis
+
+Present a clear summary:
+```
+Diagnosis: [COMPONENT] issue in [WORKSPACE]
+Error: [error message or behavior]
+Root Cause: [e.g., Model "gpt-4" not configured in gateway routes]
+Evidence: [relevant API response or log lines]
+Suggested Fix: [specific action, e.g., "Add gpt-4 route via ai-gateway skill"]
+```
+
+Do NOT auto-fix. Present the diagnosis and let the user decide next steps.
+
+## ESCALATION
+
+If you cannot determine the root cause:
+1. Suggest checking the TrueFoundry dashboard for more details
+2. Recommend reviewing the AI Gateway monitoring tab
+3. Note any unusual patterns for manual investigation

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,13 +1,44 @@
 {
-  "description": "Auto-approve TrueFoundry API calls",
+  "description": "TrueFoundry Gateway plugin hooks: env bootstrap, auto-approve API calls, delete blocking, and secret scanning",
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/plugin-scripts/session-start.sh\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/plugin-scripts/block-delete-operations.sh\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/auto-approve-tfy-api.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/plugin-scripts/pre-tool-secret-scan.sh\"",
+            "timeout": 5
           }
         ]
       }

--- a/plugin-scripts/block-delete-operations.sh
+++ b/plugin-scripts/block-delete-operations.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block ALL DELETE API operations.
+# This plugin must NEVER perform delete operations. Instead it instructs the
+# user to delete resources manually via the TrueFoundry dashboard.
+#
+# Reads hook JSON from stdin (has tool_input.command).
+# Exit 1 = block the command, exit 2 = no opinion (non-delete commands).
+
+set -e
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+
+# Nothing to check if command is empty
+if [[ -z "$COMMAND" ]]; then
+  exit 2
+fi
+
+BLOCKED=false
+RESOURCE="the resource"
+
+# --- Pattern 1: tfy-api.sh DELETE ... ---
+if [[ "$COMMAND" =~ tfy-api\.sh[[:space:]]+DELETE ]]; then
+  BLOCKED=true
+  # Try to extract the endpoint path for a friendlier message
+  endpoint=$(echo "$COMMAND" | grep -oE 'DELETE[[:space:]]+[^[:space:]]+' | head -1 | awk '{print $2}')
+  if [[ -n "$endpoint" ]]; then
+    RESOURCE="$endpoint"
+  fi
+fi
+
+# --- Pattern 2: curl ... -X DELETE ... or curl ... --request DELETE ... ---
+if [[ "$COMMAND" =~ curl[[:space:]] ]]; then
+  if [[ "$COMMAND" =~ -X[[:space:]]*DELETE ]] || [[ "$COMMAND" =~ -XDELETE ]] || [[ "$COMMAND" =~ --request[[:space:]]+DELETE ]]; then
+    BLOCKED=true
+    # Try to extract the URL for a friendlier message
+    url=$(echo "$COMMAND" | grep -oE 'https?://[^[:space:]"'"'"']+' | head -1)
+    if [[ -n "$url" ]]; then
+      RESOURCE="$url"
+    fi
+  fi
+fi
+
+# --- Pattern 3: tfy CLI destructive commands ---
+if [[ "$COMMAND" =~ (^|[[:space:];&|])(tfy[[:space:]]+(delete|destroy|remove|purge)) ]]; then
+  BLOCKED=true
+  # Extract the subcommand for context
+  subcmd=$(echo "$COMMAND" | grep -oE 'tfy[[:space:]]+(delete|destroy|remove|purge)[^;&|]*' | head -1)
+  if [[ -n "$subcmd" ]]; then
+    RESOURCE="target of '$subcmd'"
+  fi
+fi
+
+if [[ "$BLOCKED" == "true" ]]; then
+  dashboard_url="${TFY_BASE_URL:-https://app.truefoundry.com}"
+  # Use jq to safely construct JSON (avoids injection from $RESOURCE)
+  if command -v jq &>/dev/null; then
+    jq -n --arg res "$RESOURCE" --arg url "$dashboard_url" \
+      '{"decision":"block","reason":"Delete operations are not supported via this plugin. To delete \($res), go to your TrueFoundry dashboard at \($url) and navigate to the resource you want to delete."}'
+  else
+    # Fallback: sanitize by removing quotes from variables
+    safe_resource="${RESOURCE//\"/}"
+    safe_url="${dashboard_url//\"/}"
+    echo "{\"decision\":\"block\",\"reason\":\"Delete operations are not supported via this plugin. To delete ${safe_resource}, go to your TrueFoundry dashboard at ${safe_url} and navigate to the resource you want to delete.\"}"
+  fi
+  exit 1
+fi
+
+# No opinion on non-delete commands
+exit 2

--- a/plugin-scripts/pre-tool-secret-scan.sh
+++ b/plugin-scripts/pre-tool-secret-scan.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash: scans commands for hardcoded secrets/credentials.
+# Blocks execution if a likely API key or token is found inline.
+#
+# Exit 0 = approve (no secrets detected).
+# Exit 2 = no opinion (not a command we care about).
+# Non-zero (1) with message = block with reason.
+
+set -e
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+
+if [[ -z "$COMMAND" ]]; then
+  exit 2
+fi
+
+# Skip simple read-only commands unless they chain into API calls
+if [[ "$COMMAND" =~ ^[[:space:]]*(ls|cat|head|tail|grep|find|echo|pwd|cd|which|tfy[[:space:]]--version) ]]; then
+  if ! echo "$COMMAND" | grep -qE '(tfy-api\.sh|/api/svc/v1/|/api/gateway/v1/)'; then
+    exit 2
+  fi
+fi
+
+# --- Pattern matching for likely hardcoded secrets ---
+blocked=false
+reason=""
+
+# TrueFoundry API keys (tfy-* pattern, typically 40+ chars)
+if echo "$COMMAND" | grep -qE '(TFY_API_KEY|api.key|api_key)[[:space:]]*[=:][[:space:]]*["'"'"']?tfy-[A-Za-z0-9]{20,}'; then
+  blocked=true
+  reason="Hardcoded TFY_API_KEY detected. Use environment variable or .env file instead."
+fi
+
+# Generic long tokens in config YAML/JSON (env var values that look like secrets)
+if echo "$COMMAND" | grep -qE 'value:[[:space:]]*["'"'"'][A-Za-z0-9+/=_-]{40,}["'"'"']'; then
+  if echo "$COMMAND" | grep -qE '(tfy-api\.sh|/api/svc/v1/|/api/gateway/v1/)'; then
+    blocked=true
+    reason="Hardcoded secret value detected in API call. Use tfy-secret:// references instead. See the secrets skill for how to create and reference secrets."
+  fi
+fi
+
+# AWS/GCP/Azure credential patterns
+if echo "$COMMAND" | grep -qE '(AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35})'; then
+  blocked=true
+  reason="Cloud provider credential detected in command. Store in TrueFoundry secrets and use tfy-secret:// references."
+fi
+
+if $blocked; then
+  echo "$reason"
+  exit 1
+fi
+
+# No secrets detected — defer to other hooks (exit 2 = no opinion)
+exit 2

--- a/plugin-scripts/session-start.sh
+++ b/plugin-scripts/session-start.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# SessionStart hook: verify TrueFoundry credentials and auto-install CLI.
+# Runs at the beginning of every Claude Code session.
+# Outputs status that feeds back into the conversation context.
+
+set -euo pipefail
+
+# --- Load .env if present (same safe parser as tfy-api.sh) ---
+if [[ -f ".env" ]]; then
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    line="${line#export }"
+    if [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+      key="${line%%=*}"
+      value="${line#*=}"
+      # Only strip matching outer quotes (avoid over-stripping mixed quotes)
+      if [[ "$value" =~ ^\".*\"$ ]]; then
+        value="${value#\"}" && value="${value%\"}"
+      elif [[ "$value" =~ ^\'.*\'$ ]]; then
+        value="${value#\'}" && value="${value%\'}"
+      fi
+      export "$key=$value"
+    fi
+  done < .env
+fi
+
+# Bridge Claude plugin userConfig values (exported as CLAUDE_PLUGIN_OPTION_<KEY>)
+# so scripts work whether credentials come from .env, env vars, or plugin userConfig.
+TFY_BASE_URL="${TFY_BASE_URL:-${CLAUDE_PLUGIN_OPTION_TFY_BASE_URL:-}}"
+TFY_API_KEY="${TFY_API_KEY:-${CLAUDE_PLUGIN_OPTION_TFY_API_KEY:-}}"
+
+# Resolve aliases
+TFY_BASE_URL="${TFY_BASE_URL:-${TFY_HOST:-${TFY_API_HOST:-}}}"
+
+# --- Credential check ---
+cred_status="ok"
+cred_messages=()
+
+if [[ -z "${TFY_BASE_URL:-}" ]]; then
+  cred_status="missing"
+  cred_messages+=("TFY_BASE_URL is not set. Export it or add to .env")
+fi
+
+if [[ -z "${TFY_API_KEY:-}" ]]; then
+  cred_status="missing"
+  cred_messages+=("TFY_API_KEY is not set. Export it or add to .env")
+fi
+
+# --- CLI check & auto-install ---
+cli_version=""
+cli_status="missing"
+cli_messages=()
+MIN_CLI_VERSION="0.5.0"
+TARGET_CLI_VERSION="0.5.0"
+
+# Helper: compare semver strings (returns 0 if $1 < $2)
+version_lt() {
+  local IFS=.
+  # shellcheck disable=SC2206
+  local i a=($1) b=($2)
+  for ((i = 0; i < ${#b[@]}; i++)); do
+    local av="${a[i]:-0}" bv="${b[i]:-0}"
+    if ((av < bv)); then return 0; fi
+    if ((av > bv)); then return 1; fi
+  done
+  return 1
+}
+
+# Helper: extract version number from tfy --version output
+extract_version() {
+  local ver_str="$1"
+  echo "$ver_str" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
+}
+
+install_tfy_cli() {
+  install_ok=false
+
+  PY_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || echo "unknown")
+  PY_MAJOR=$(echo "$PY_VERSION" | cut -d. -f1)
+  PY_MINOR=$(echo "$PY_VERSION" | cut -d. -f2)
+
+  has_uv=false
+  has_pip=false
+  command -v uv &>/dev/null && has_uv=true
+  python3 -m pip --version &>/dev/null 2>&1 && has_pip=true
+
+  if $has_uv; then
+    if uv tool install --python 3.12 "truefoundry==${TARGET_CLI_VERSION}" 2>/dev/null; then
+      install_ok=true
+    fi
+  elif [[ "$PY_VERSION" = "unknown" ]]; then
+    cli_messages+=("No python3 found. Install Python 3.9+ or uv (https://docs.astral.sh/uv/)")
+  elif [[ "$PY_MAJOR" -eq 3 && "$PY_MINOR" -lt 9 ]]; then
+    cli_messages+=("Python ${PY_VERSION} is not supported. TrueFoundry CLI requires Python 3.9+")
+  elif ! $has_pip; then
+    cli_messages+=("No Python package manager found. Install pip or uv (https://docs.astral.sh/uv/)")
+  elif [[ "$PY_MAJOR" -eq 3 && "$PY_MINOR" -ge 14 ]]; then
+    if python3 -m pip install --quiet "truefoundry==${TARGET_CLI_VERSION}" "pydantic>=2.13.0b1" 2>/dev/null; then
+      install_ok=true
+    else
+      cli_messages+=("Python ${PY_VERSION} install failed. Python 3.14+ requires pydantic beta which may not be available yet. Try: uv tool install --python 3.12 truefoundry==${TARGET_CLI_VERSION}")
+    fi
+  else
+    if python3 -m pip install --quiet "truefoundry==${TARGET_CLI_VERSION}" 2>/dev/null; then
+      install_ok=true
+    fi
+  fi
+}
+
+if tfy_ver=$(tfy --version 2>/dev/null); then
+  cli_version="$tfy_ver"
+  cli_status="ok"
+
+  parsed_ver=$(extract_version "$tfy_ver")
+  if [[ -n "$parsed_ver" ]] && version_lt "$parsed_ver" "$MIN_CLI_VERSION"; then
+    cli_messages+=("CLI version ${parsed_ver} is outdated (minimum: ${MIN_CLI_VERSION}). Upgrading...")
+    cli_status="upgrading"
+    install_tfy_cli
+    if $install_ok && tfy_ver=$(tfy --version 2>/dev/null); then
+      cli_version="$tfy_ver"
+      cli_status="upgraded"
+      cli_messages+=("Upgraded to ${cli_version}")
+    else
+      cli_status="outdated"
+      cli_messages+=("Auto-upgrade failed. Please run: pip install --upgrade truefoundry==${TARGET_CLI_VERSION}")
+    fi
+  fi
+else
+  cli_status="installing"
+  install_tfy_cli
+
+  if $install_ok && tfy_ver=$(tfy --version 2>/dev/null); then
+    cli_version="$tfy_ver"
+    cli_status="installed"
+  else
+    cli_status="unavailable"
+  fi
+fi
+
+# --- Connection test (only if credentials are present) ---
+conn_status="skipped"
+conn_messages=()
+workspace_count=0
+workspace_names=()
+
+if [[ "$cred_status" = "ok" ]]; then
+  BASE="${TFY_BASE_URL%/}"
+  response_file=$(mktemp)
+  http_code=$(curl -s -o "$response_file" -w '%{http_code}' \
+    --connect-timeout 5 --max-time 10 \
+    -H "Authorization: Bearer ${TFY_API_KEY}" \
+    "${BASE}/api/svc/v1/workspaces" 2>/dev/null || echo "000")
+
+  if [[ "$http_code" =~ ^2 ]]; then
+    conn_status="connected"
+
+    if command -v python3 &>/dev/null; then
+      workspace_info=$(python3 -c "
+import json, sys
+try:
+    data = json.load(open('$response_file'))
+    workspaces = data if isinstance(data, list) else data.get('workspaces', data.get('data', []))
+    names = [w.get('name', w.get('fqn', 'unnamed')) for w in workspaces if isinstance(w, dict)]
+    print(len(names))
+    for n in names:
+        print(n)
+except Exception:
+    print('0')
+" 2>/dev/null || echo "0")
+
+      workspace_count=$(echo "$workspace_info" | head -1)
+      if [[ "$workspace_count" -gt 0 ]] 2>/dev/null; then
+        while IFS= read -r ws_name; do
+          workspace_names+=("$ws_name")
+        done < <(echo "$workspace_info" | tail -n +2)
+      fi
+
+      if [[ "$workspace_count" -eq 0 ]]; then
+        conn_messages+=("WARNING: API key has access to zero workspaces. The key may have insufficient permissions.")
+      fi
+    fi
+  elif [[ "$http_code" = "401" || "$http_code" = "403" ]]; then
+    conn_status="auth_failed"
+    conn_messages+=("API key is invalid, expired, or has insufficient permissions")
+  elif [[ "$http_code" = "404" ]]; then
+    conn_status="endpoint_not_found"
+    conn_messages+=("TFY_BASE_URL may be incorrect - the API endpoint was not found at ${BASE}/api/svc/v1/workspaces")
+  elif [[ "$http_code" =~ ^5 ]]; then
+    conn_status="server_error"
+    conn_messages+=("TrueFoundry server error (HTTP ${http_code}) - the platform may be experiencing issues")
+  elif [[ "$http_code" = "000" ]]; then
+    conn_status="unreachable"
+    conn_messages+=("Cannot reach TrueFoundry at ${BASE} - check network/VPN")
+  else
+    conn_status="unreachable"
+    conn_messages+=("Unexpected HTTP ${http_code} from TrueFoundry at ${BASE}")
+  fi
+
+  rm -f "$response_file"
+fi
+
+# --- Output summary ---
+echo "TrueFoundry environment check:"
+echo "  Credentials: $cred_status"
+for msg in "${cred_messages[@]+"${cred_messages[@]}"}"; do
+  echo "    - $msg"
+done
+echo "  CLI: $cli_status${cli_version:+ ($cli_version)}"
+for msg in "${cli_messages[@]+"${cli_messages[@]}"}"; do
+  echo "    - $msg"
+done
+echo "  Connection: $conn_status"
+for msg in "${conn_messages[@]+"${conn_messages[@]}"}"; do
+  echo "    - $msg"
+done
+
+if [[ "$conn_status" = "connected" ]]; then
+  echo "  Workspaces accessible: $workspace_count"
+  if [[ ${#workspace_names[@]} -gt 0 ]]; then
+    for ws in "${workspace_names[@]}"; do
+      echo "    - $ws"
+    done
+  fi
+fi
+
+if [[ "$cred_status" != "ok" ]]; then
+  echo ""
+  echo "Set credentials before configuring the gateway:"
+  echo "  export TFY_BASE_URL=https://your-org.truefoundry.cloud"
+  echo "  export TFY_API_KEY=your-api-key"
+  echo "Or add them to a .env file in your project directory."
+fi
+
+if [[ "$conn_status" = "auth_failed" ]]; then
+  echo ""
+  echo "API key is invalid, expired, or has insufficient permissions. Generate a new one at:"
+  echo "  ${TFY_BASE_URL%/}/settings"
+fi
+
+if [[ "$conn_status" = "endpoint_not_found" ]]; then
+  echo ""
+  echo "Verify TFY_BASE_URL is correct (e.g., https://your-org.truefoundry.cloud)"
+fi

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -12,14 +12,6 @@ fail() {
   errors=$((errors + 1))
 }
 
-require_file_contains() {
-  local file="$1"
-  local needle="$2"
-  if ! grep -Fq "$needle" "$file"; then
-    fail "$file missing required text: $needle"
-  fi
-}
-
 get_frontmatter_block() {
   local file="$1"
   awk '


### PR DESCRIPTION
## Summary

Converts the repo from pure skills into a **multi-platform plugin** supporting Claude Code, Codex CLI, and Cursor — while keeping all 16 skills backward-compatible.

- **Claude Code plugin** (`.claude-plugin/`): plugin manifest, marketplace metadata, `userConfig` for `TFY_BASE_URL`/`TFY_API_KEY`
- **Codex CLI plugin** (`.codex-plugin/`): plugin manifest, marketplace metadata, hooks in Codex format
- **Cursor rules** (`.cursor/rules/`): 3 advisory rule files (security, gateway, workflow)
- **2 agents** (`agents/`): gateway-configurator (orchestrated config workflow) and troubleshoot (failure diagnosis)
- **3 plugin hooks** (`plugin-scripts/`): session-start (credential + CLI bootstrap), block-delete-operations, pre-tool-secret-scan

### Feature Comparison

| Feature | Claude Code | Codex CLI | Cursor | Standalone Skills |
|---------|:-----------:|:---------:|:------:|:-----------------:|
| 16 skills | yes | yes | yes | yes |
| Hook enforcement | yes | yes | no | no |
| Auto credential check | yes | yes | no | no |
| Delete blocking | yes | yes | no | no |
| Secret scan | yes | yes | no | no |
| Specialized agents | yes | no | no | no |
| CLI auto-install | yes | yes | no | no |

### New files (15)
- `.claude-plugin/plugin.json`, `marketplace.json`
- `.codex-plugin/plugin.json`, `marketplace.json`
- `.codex/hooks.json`
- `.cursor/rules/security.mdc`, `gateway.mdc`, `workflow.mdc`
- `agents/gateway-configurator.md`, `troubleshoot.md`
- `plugin-scripts/session-start.sh`, `block-delete-operations.sh`, `pre-tool-secret-scan.sh`

### Modified files (6)
- `hooks/hooks.json` — added SessionStart, block-delete, secret-scan hooks
- `AGENTS.md` — expanded with agent workflows and error patterns
- `README.md` — restructured to plugin-first install with feature comparison
- `CONTRIBUTING.md` — added plugin-scripts shellcheck
- `.gitignore` — un-ignored `.codex/hooks.json`, `.cursor/rules/`, `AGENTS.md`
- `scripts/validate-skills.sh` — removed unused `require_file_contains()`

## Test plan
- [x] `shellcheck plugin-scripts/*.sh` — all pass
- [x] JSON validation on all 5 manifests — all valid
- [x] `./scripts/validate-skills.sh` — passes
- [x] `./scripts/validate-skill-security.sh` — passes
- [x] `./scripts/test-tfy-api.sh` — passes
- [ ] `claude --plugin-dir .` to test locally
- [ ] Verify SessionStart hook runs on session open
- [ ] Verify delete operations are blocked
- [ ] Verify secret scan blocks hardcoded credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds multiple new hook-executed shell scripts (credential bootstrap, CLI auto-install, delete blocking, secret scanning) that run automatically and can affect user environments and command execution. Most logic is guardrail-oriented, but mistakes could block legitimate workflows or mishandle env parsing/CLI installation.
> 
> **Overview**
> Converts the repository from standalone skills into a **multi-platform plugin distribution** by adding Claude and Codex marketplace/manifest files plus Cursor rule docs, while keeping the existing `skills/` layout.
> 
> Adds **enforcement hooks**: a `SessionStart` bootstrap (`plugin-scripts/session-start.sh`) that loads `.env`/plugin `userConfig`, checks credentials, auto-installs/upgrades the `tfy` CLI, and tests connectivity; and `PreToolUse` guards that **block delete operations** (`block-delete-operations.sh`) and **block hardcoded secrets in commands** (`pre-tool-secret-scan.sh`), alongside the existing `auto-approve-tfy-api.sh`.
> 
> Introduces two Claude agents (`agents/gateway-configurator.md`, `agents/troubleshoot.md`) and updates docs (`README.md`, `AGENTS.md`, `CONTRIBUTING.md`) plus ignores (`.gitignore`) to reflect plugin-first install and validation; minor cleanup removes an unused helper from `scripts/validate-skills.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2642e09edd48803cc84e500c9b425a1955241ab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->