### PR TITLE
[codex] Add tfy CLI reference drift checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 TFY_BASE_URL=https://your-org.truefoundry.cloud
 TFY_HOST=https://your-org.truefoundry.cloud
-TFY_API_KEY=tfy-...
+
+# Optional. Only needed for direct REST helper checks or Gateway model calls.
+# Leave blank for first-time onboarding and interactive `tfy login`.
+TFY_API_KEY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,5 +132,4 @@ Before submitting a PR:
 ## Questions?
 
 - Open an issue at https://github.com/truefoundry/skills/issues
-- See [AGENTS.md](AGENTS.md) for agent-specific documentation
 - See [SUPPORT.md](SUPPORT.md) for troubleshooting guidance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,7 @@ Before submitting a PR:
 2. Run validation and failure-mode tests:
    ```bash
    ./scripts/validate-skills.sh
+   ./scripts/check-tfy-cli-reference.sh
    ./scripts/validate-skill-security.sh
    ./scripts/test-tfy-api.sh
    ```

--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ This is the official skills repo — it lets your coding agent set up and manage
 
 ## Setup
 
-Paste into Claude Code, Codex, or Cursor:
+Install the skills:
 
-```text
-Read https://github.com/truefoundry/skills/install.md and follow the instructions to register with TrueFoundry.
+```bash
+npx skills add truefoundry/skills
 ```
 
-The agent will walk you through registration, CLI install, and `tfy login`. Nothing else runs until login is verified.
+Then open Claude Code, Codex, or Cursor and say:
+
+```text
+sign me up for truefoundry
+```
+
+The agent will check the CLI, walk you through account creation if needed, run `tfy login --host <tenant-url>`, and stop once login is verified.
 
 <details>
 <summary><strong>Install the plugin</strong></summary>

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -8,6 +8,6 @@ First check whether `tfy login` is already complete. If it is missing, use the o
 
 For first-time setup, tell the user:
 
-> Read https://www.github.com/truefoundry/skills/install.md and follow the instructions to register with TrueFoundry.
+> Read https://raw.githubusercontent.com/truefoundry/skills/main/install.md and follow the instructions to register with TrueFoundry.
 
 After onboarding is complete, help route the current project through the gateway and print a summary of what was configured.

--- a/install.md
+++ b/install.md
@@ -2,7 +2,7 @@
 
 Paste this into Claude Code, Codex, Cursor, or any coding agent that can read a URL:
 
-> Read https://www.github.com/truefoundry/skills/install.md and follow the instructions to register with TrueFoundry.
+> Read https://raw.githubusercontent.com/truefoundry/skills/main/install.md and follow the instructions to register with TrueFoundry.
 
 The agent should use the `truefoundry-onboard` skill and follow this exact flow:
 

--- a/scripts/check-tfy-cli-reference.sh
+++ b/scripts/check-tfy-cli-reference.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REFERENCE_FILE="$REPO_ROOT/skills/_shared/references/cli-reference.md"
+
+if ! command -v tfy >/dev/null 2>&1; then
+  echo "Skipping tfy CLI reference drift check: tfy is not installed."
+  exit 0
+fi
+
+errors=0
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fail() {
+  echo "ERROR: $*" >&2
+  errors=$((errors + 1))
+}
+
+commands_from_help() {
+  sed -n -E 's/^│[[:space:]]+([a-z][a-z0-9-]*)[[:space:]]{2,}.*/\1/p' | sort -u
+}
+
+expected_subcommands() {
+  case "$*" in
+    "")
+      printf '%s\n' \
+        apply \
+        delete \
+        deploy \
+        deploy-init \
+        get \
+        login \
+        logout \
+        ml \
+        patch \
+        patch-application \
+        terminate \
+        trigger
+      ;;
+    "delete")
+      printf '%s\n' application workspace
+      ;;
+    "deploy")
+      printf '%s\n' workflow
+      ;;
+    "deploy-init")
+      printf '%s\n' model
+      ;;
+    "get")
+      printf '%s\n' kubeconfig
+      ;;
+    "ml")
+      printf '%s\n' download
+      ;;
+    "ml download")
+      printf '%s\n' artifact model
+      ;;
+    "terminate")
+      printf '%s\n' job
+      ;;
+    "trigger")
+      printf '%s\n' job workflow
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+check_command_group() {
+  local group="$1"
+  local label="tfy"
+  local help_output
+  local args=()
+  local expected_file="$tmp_dir/expected-${group// /_}-commands.txt"
+  local actual_file="$tmp_dir/actual-${group// /_}-commands.txt"
+  local missing_file="$tmp_dir/missing-${group// /_}-commands.txt"
+  local unexpected_file="$tmp_dir/unexpected-${group// /_}-commands.txt"
+
+  if [[ -n "$group" ]]; then
+    label="tfy $group"
+    read -r -a args <<<"$group"
+  fi
+
+  if ! expected_subcommands "$group" >"$expected_file"; then
+    fail "no expected command list configured for $label"
+    return
+  fi
+
+  if [[ "${#args[@]}" -eq 0 ]]; then
+    help_output="$(tfy --help 2>&1)" || {
+      fail "$label --help failed"
+      return
+    }
+  elif ! help_output="$(tfy "${args[@]}" --help 2>&1)"; then
+    fail "$label --help failed"
+    return
+  fi
+
+  printf '%s\n' "$help_output" | commands_from_help >"$actual_file"
+
+  comm -23 "$expected_file" "$actual_file" >"$missing_file"
+  comm -13 "$expected_file" "$actual_file" >"$unexpected_file"
+
+  if [[ -s "$missing_file" ]]; then
+    fail "$label --help is missing documented command(s): $(paste -sd ', ' "$missing_file")"
+  fi
+
+  if [[ -s "$unexpected_file" ]]; then
+    fail "$label --help has new undocumented command(s): $(paste -sd ', ' "$unexpected_file")"
+  fi
+}
+
+check_help_exists() {
+  local command_path="$*"
+  local args=()
+  read -r -a args <<<"$command_path"
+
+  if ! tfy "${args[@]}" --help >/dev/null 2>&1; then
+    fail "documented command does not expose help: tfy $command_path --help"
+  fi
+}
+
+check_invalid_command_fails() {
+  local command_path="$*"
+  local args=()
+  read -r -a args <<<"$command_path"
+
+  if tfy "${args[@]}" --help >/dev/null 2>&1; then
+    fail "command is documented as invalid but exists: tfy $command_path"
+  fi
+}
+
+check_reference_mentions() {
+  local text="$1"
+
+  if ! grep -Fq -- "$text" "$REFERENCE_FILE"; then
+    fail "cli-reference.md does not mention expected text: $text"
+  fi
+}
+
+echo "Checking tfy CLI reference against installed CLI..."
+echo "Using $(tfy --version)"
+
+check_command_group ""
+check_command_group "delete"
+check_command_group "deploy"
+check_command_group "deploy-init"
+check_command_group "get"
+check_command_group "ml"
+check_command_group "ml download"
+check_command_group "terminate"
+check_command_group "trigger"
+
+while IFS= read -r command_path; do
+  [[ -z "$command_path" ]] && continue
+  check_help_exists "$command_path"
+done <<'EOF'
+apply
+delete
+delete application
+delete workspace
+deploy
+deploy workflow
+deploy-init model
+get kubeconfig
+login
+logout
+ml download artifact
+ml download model
+patch
+patch-application
+terminate job
+trigger job
+trigger workflow
+EOF
+
+while IFS= read -r command_path; do
+  [[ -z "$command_path" ]] && continue
+  check_invalid_command_fails "$command_path"
+done <<'EOF'
+whoami
+show-config
+status
+config
+list
+describe
+logs
+exec
+init
+create
+ask
+download
+upload
+EOF
+
+check_reference_mentions "This reference is grounded in \`tfy --help\` from \`tfy 0.13.12\`."
+check_reference_mentions "| \`tfy get kubeconfig\` |"
+check_reference_mentions "| \`tfy trigger workflow\` |"
+check_reference_mentions "These commands exist in the CLI but must not be executed by these skills."
+check_reference_mentions "- \`tfy show-config\`"
+
+if [[ "$errors" -gt 0 ]]; then
+  echo "tfy CLI reference drift check failed with $errors error(s)." >&2
+  exit 1
+fi
+
+echo "tfy CLI reference drift check passed."

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -113,6 +113,12 @@ if [[ "$installer_skills" != "$all_skill_dirs" ]]; then
   fail "install skill list mismatch. expected='$all_skill_dirs' actual='$installer_skills'"
 fi
 
+echo "Validating tfy CLI reference..."
+
+if ! "$REPO_ROOT/scripts/check-tfy-cli-reference.sh"; then
+  errors=$((errors + 1))
+fi
+
 if [[ "$errors" -gt 0 ]]; then
   echo "Validation failed with $errors error(s)." >&2
   exit 1

--- a/skills/_shared/references/cli-reference.md
+++ b/skills/_shared/references/cli-reference.md
@@ -1,6 +1,10 @@
 # TrueFoundry CLI Reference
 
-The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for querying, listing, or inspecting resources. For read operations, use the REST API via `tfy-api.sh`.
+This reference is grounded in `tfy --help` from `tfy 0.13.12`.
+
+Do not guess `tfy` subcommands from common CLI patterns. Before using any `tfy` command not shown in this file, run `tfy --help` or `tfy <subcommand> --help` and use only commands that appear in that help output.
+
+For gateway/platform read operations, prefer the REST API via `tfy-api.sh`. The CLI has `tfy get kubeconfig`, but it does not provide general list/describe/status commands for TrueFoundry resources.
 
 ## Installation
 
@@ -8,127 +12,335 @@ The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for queryi
 pip install -U "truefoundry"
 ```
 
-Requires Python 3.9–3.14. Optional extras:
-- `pip install -U "truefoundry[workflow]"` — workflow support (Python 3.9–3.12)
-- `pip install -U "truefoundry[workflow,spark]"` — workflow + Spark
+Requires Python 3.9-3.14. Optional extras:
+- `pip install -U "truefoundry[workflow]"` - workflow support (Python 3.9-3.12)
+- `pip install -U "truefoundry[workflow,spark]"` - workflow + Spark
 
-## Commands
+## Global Options
 
-### tfy login
+| Command | Purpose |
+|---|---|
+| `tfy --version` | Print the installed CLI version. |
+| `tfy --json <command>` | Output entities in JSON format where the command supports entities. |
+| `tfy --debug <command>` | Enable debug logging. Can also be set with `TFY_DEBUG=1`. |
+| `tfy --help` / `tfy -h` | Show top-level help. |
+
+## Command Index
+
+| Command | Purpose | Skill usage guidance |
+|---|---|---|
+| `tfy apply` | Create/update resources from manifest files. | Allowed only after dry-run/diff plus explicit user confirmation. |
+| `tfy delete` | Delete resources. | Do not execute from skills; provide manual dashboard instructions instead. |
+| `tfy deploy` | Deploy an application from a `truefoundry.yaml` file. | Confirm workspace before use. |
+| `tfy deploy workflow` | Deploy a workflow file. | Confirm workspace before use. |
+| `tfy deploy-init model` | Generate model server application code for a model version. | Safe scaffolding command; still confirm output path. |
+| `tfy get kubeconfig` | Update kubeconfig for a TrueFoundry cluster. | Only CLI read-style command observed. |
+| `tfy login` | Login to a TrueFoundry tenant. | Valid onboarding command. |
+| `tfy logout` | Logout from the current session. | Do not run unless the user explicitly asks. |
+| `tfy ml download artifact` | Download a logged artifact version. | Writes files locally; confirm path/overwrite. |
+| `tfy ml download model` | Download a logged model version. | Writes files locally; confirm path/overwrite. |
+| `tfy patch` | Patch a local YAML file with a `yq` filter. | Local file mutation; review target file/output path first. |
+| `tfy patch-application` | Patch and deploy an existing application. | Deployment mutation; requires explicit user confirmation. |
+| `tfy terminate job` | Terminate a job run. | Do not execute from skills; destructive operational action. |
+| `tfy trigger job` | Trigger a job run asynchronously. | Ask before triggering; may start compute/cost. |
+| `tfy trigger workflow` | Trigger a workflow run. | Ask before triggering; may start compute/cost. |
+
+## Authentication
+
+### `tfy login`
 
 Authenticate the CLI against a TrueFoundry tenant.
 
 ```bash
-# Interactive (opens browser for device code flow) — recommended
+# Interactive login
 tfy login --host https://your-org.truefoundry.cloud
 
-# Non-interactive (CI/CD only — key appears in shell history)
+# Non-interactive login
 tfy login --host https://your-org.truefoundry.cloud --api-key "$TFY_API_KEY"
 ```
 
-Stores credentials in `~/.truefoundry/credentials.json`.
+Options:
+- `--host TEXT` - required tenant URL; can be set with `TFY_HOST`.
+- `--api-key TEXT` / `--api_key TEXT` - API key for non-interactive login.
+- `--relogin` - force relogin.
+- `--help` / `-h` - show command help.
 
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--host` | Yes | Tenant URL (e.g. `https://acme.truefoundry.cloud`) |
-| `--api-key` | No | API key for non-interactive login (CI/CD) |
+After `tfy login`, credentials are stored in:
 
-### tfy apply
-
-Create or update resources from YAML manifests.
-
-```bash
-# Single file
-tfy apply -f manifest.yaml
-
-# Multiple files
-tfy apply -f manifest1.yaml -f manifest2.yaml
-
-# Entire directory (recursive, discovers *.yaml and *.yml)
-tfy apply --dir ./manifests
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) to apply. Repeatable. |
-| `--dir <path>` | Directory of manifests (cannot combine with `-f`) |
-| `--dry-run` | Simulate changes without persisting |
-| `--show-diff` | Show diff between manifest and deployed state |
-| `--diffs-only` | Apply only changed files vs HEAD (requires `--dir`) |
-| `--ref <ref>` | Git ref to diff against (default: HEAD). Use with `--diffs-only` |
-| `--sync` | Delete platform resources for removed YAML files (requires `--dir` + `--diffs-only`) |
-
-**Supported resource types:** provider-account, gateway-load-balancing-config, gateway-rate-limiting-config, gateway-budget-config, gateway-guardrails-config, mcp-server, workspace, cluster, application, secret-group, ml-repo, agent, agent-skill
-
-**Environment:** Requires `TFY_HOST` to be set when `TFY_API_KEY` is in the environment:
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
-```
-
-### tfy delete
-
-Delete resources using the same manifest files used with `tfy apply`.
-
-```bash
-# Single file
-tfy delete -f manifest.yaml
-
-# Multiple files
-tfy delete -f manifest1.yaml -f manifest2.yaml
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) identifying resources to delete. Repeatable. |
-
-### tfy --version
-
-Print the installed CLI version.
-
-```bash
-tfy --version
-# Output: tfy version X.Y.Z
-```
-
-## Commands That DO NOT Exist
-
-The following are **not valid** `tfy` subcommands. Do not attempt them:
-
-- `tfy get` / `tfy list` / `tfy describe`
-- `tfy config` / `tfy config get` / `tfy config set`
-- `tfy whoami` / `tfy status`
-- `tfy download` / `tfy upload`
-- `tfy init` / `tfy create`
-- `tfy logs` / `tfy exec`
-
-For all read/query operations, use the REST API directly via `tfy-api.sh` or `curl`.
-
-## Authentication Modes
-
-| Mode | How | When |
-|------|-----|------|
-| Interactive login | `tfy login --host <url>` | Local development |
-| Environment variables | `TFY_HOST` + `TFY_API_KEY` | CI/CD, scripts, `tfy-api.sh` |
-| Non-interactive login | `tfy login --host <url> --api-key <key>` | CI/CD (key in history — prefer env vars) |
-
-## Credential Storage
-
-After `tfy login`, credentials are stored at:
-```
+```text
 ~/.truefoundry/credentials.json
 ```
 
-Fields: `host`, `access_token`, `refresh_token`.
+Fields include `host`, `access_token`, and `refresh_token`.
+
+### `tfy logout`
+
+Logout from the current TrueFoundry session.
+
+```bash
+tfy logout
+```
+
+Do not run this unless the user explicitly asks to logout.
+
+## Apply And Deploy
+
+### `tfy apply`
+
+Create or update resources from manifest files.
+
+```bash
+tfy apply -f manifest.yaml
+tfy apply -f manifest1.yaml -f manifest2.yaml
+tfy apply -f manifest.yaml --dry-run --show-diff
+```
+
+Options:
+- `--file FILE` / `-f FILE` - required manifest file. Repeat for multiple files.
+- `--dry-run` / `--dry_run` - simulate without applying.
+- `--show-diff` / `--show_diff` - print manifest differences when using `--dry-run`.
+- `--help` / `-h` - show command help.
+
+Before the final non-dry-run apply, show the target host/workspace, an English summary, the YAML or diff, the exact command, and wait for explicit user confirmation.
+
+### `tfy deploy`
+
+Deploy an application to TrueFoundry.
+
+```bash
+tfy deploy -f truefoundry.yaml -w "<workspace-fqn>"
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to `truefoundry.yaml`.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - workspace FQN. If omitted, the CLI reads it from the deployment spec when available.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--force` / `--no-force` - cancel ongoing deployments and force a new one. Defaults to no-force.
+- `--trigger-on-deploy` / `--trigger_on_deploy` / `--no-trigger-on-deploy` / `--no_trigger_on_deploy` - trigger a job run after deployment succeeds. No effect for non-job deployments.
+- `--help` / `-h` - show command help.
+
+Always confirm the workspace before deployment. Treat `--force` and trigger-on-deploy as higher-risk options requiring explicit user confirmation.
+
+### `tfy deploy workflow`
+
+Deploy a workflow file.
+
+```bash
+tfy deploy workflow --name "<workflow-name>" -f workflow.py -w "<workspace-fqn>"
+```
+
+Options:
+- `--name TEXT` / `-n TEXT` - required workflow name.
+- `--file FILE` / `-f FILE` - required workflow file.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - required workspace FQN.
+- `--help` / `-h` - show command help.
+
+### `tfy deploy-init model`
+
+Generate application code for a model server deployment.
+
+```bash
+tfy deploy-init model \
+  --name "<application-name>" \
+  --model-version-fqn "<model-version-fqn>" \
+  --workspace-fqn "<workspace-fqn>" \
+  --model-server fastapi \
+  --output-dir ./model-server
+```
+
+Options:
+- `--name APPLICATION-NAME` - required model server deployment name.
+- `--model-version-fqn NON-EMPTY-STRING` / `--model_version_fqn` - required model version FQN.
+- `--workspace-fqn NON-EMPTY-STRING` / `--workspace_fqn` / `-w` - required workspace FQN.
+- `--model-server [triton|fastapi]` / `--model_server` - model server type. Defaults to `fastapi`.
+- `--output-dir DIRECTORY` / `--output_dir` - output directory for generated code.
+- `--help` / `-h` - show command help.
+
+## Local Patching
+
+### `tfy patch`
+
+Patch a local YAML file with a `yq` filter.
+
+```bash
+tfy patch -f servicefoundry.yaml --filter '.image.image_uri = "repo/image:tag"' -o patched.yaml
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to servicefoundry YAML. Defaults to `./servicefoundry.yaml`.
+- `--filter TEXT` - required `yq` filter.
+- `--output-file PATH` / `-o PATH` - write output to a file.
+- `--indent INTEGER` / `-I INTEGER` - output indent. Defaults to `4`.
+- `--help` / `-h` - show command help.
+
+### `tfy patch-application`
+
+Patch and deploy an existing application.
+
+```bash
+tfy patch-application --application-fqn "<application-fqn>" --patch-file patch.yaml
+tfy patch-application --application-fqn "<application-fqn>" --patch '{"key":"value"}'
+```
+
+Options:
+- `--patch-file FILE` / `--patch_file FILE` / `-f FILE` - YAML patch file.
+- `--patch TEXT` / `-p TEXT` - JSON patch string.
+- `--application-fqn TEXT` / `--application_fqn TEXT` / `-a TEXT` - required application FQN.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--help` / `-h` - show command help.
+
+This mutates a live application. Show the patch and wait for explicit user confirmation before running.
+
+## Read-Style Commands
+
+### `tfy get kubeconfig`
+
+Update kubeconfig to access a cluster attached to the TrueFoundry Control Plane.
+
+```bash
+tfy get kubeconfig --cluster "<cluster-id>" --overwrite
+```
+
+Options:
+- `--cluster TEXT` / `-c TEXT` - cluster ID. If omitted, the CLI opens an interactive cluster picker.
+- `--overwrite` - overwrite an existing cluster entry without prompting.
+- `--help` / `-h` - show command help.
+
+This writes to `~/.kube/config` by default, or to the first path in `KUBECONFIG`.
+
+## Triggering Work
+
+### `tfy trigger job`
+
+Trigger a job asynchronously.
+
+```bash
+tfy trigger job --application-fqn "<cluster:workspace:job>"
+tfy trigger job --application-fqn "<cluster:workspace:job>" --command "python run.py"
+tfy trigger job --application-fqn "<cluster:workspace:job>" -- --param value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required job deployment FQN.
+- `--command TEXT` - command to run.
+- `--run-name-alias TEXT` / `--run_name_alias TEXT` - alias for the job run name.
+- `--help` / `-h` - show command help.
+
+Ask before triggering jobs because it can start compute and cost.
+
+### `tfy trigger workflow`
+
+Trigger a workflow.
+
+```bash
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>"
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>" -- --input value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required workflow application FQN.
+- `--help` / `-h` - show command help.
+
+Ask before triggering workflows because it can start compute and cost.
+
+## ML Downloads
+
+### `tfy ml download artifact`
+
+Download a logged artifact version.
+
+```bash
+tfy ml download artifact --fqn "<artifact-version-fqn>" --path ./downloads
+```
+
+Options:
+- `--fqn TEXT` - required artifact version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+### `tfy ml download model`
+
+Download a logged model version.
+
+```bash
+tfy ml download model --fqn "<model-version-fqn>" --path ./models
+```
+
+Options:
+- `--fqn TEXT` - required model version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+## Destructive Or Blocked Commands
+
+These commands exist in the CLI but must not be executed by these skills. Provide manual dashboard instructions instead.
+
+### `tfy delete`
+
+Delete TrueFoundry resources.
+
+Observed forms:
+- `tfy delete -f manifest.yaml`
+- `tfy delete application --application-fqn "<application-fqn>"`
+- `tfy delete workspace --workspace-fqn "<workspace-fqn>"`
+
+Options:
+- `--file FILE` / `-f FILE` - manifest file(s) identifying resources to delete.
+- `tfy delete application`: `--application-fqn TEXT` / `--application_fqn TEXT`, `--yes`.
+- `tfy delete workspace`: `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT`, `--yes`.
+
+### `tfy terminate job`
+
+Terminate a job run.
+
+```bash
+tfy terminate job --job-fqn "<job-fqn>" --job-run-name "<run-name>"
+```
+
+Options:
+- `--job-fqn TEXT` / `--job_fqn TEXT` - required job FQN.
+- `--job-run-name TEXT` / `--job_run_name TEXT` - required run name.
+- `--help` / `-h` - show command help.
+
+## Commands That Do Not Exist In `tfy 0.13.12`
+
+The following are not valid `tfy` commands. Do not attempt them:
+
+- `tfy whoami`
+- `tfy show-config`
+- `tfy status`
+- `tfy config`, `tfy config get`, `tfy config set`
+- `tfy list`
+- `tfy describe`
+- `tfy logs`
+- `tfy exec`
+- `tfy init`
+- `tfy create`
+- `tfy ask`
+- top-level `tfy download` or `tfy upload` (`tfy ml download ...` is valid)
 
 ## Decision Tree
 
-```
-Need to CREATE/UPDATE/DELETE a resource?
-  → tfy apply / tfy delete
-
-Need to READ/LIST/QUERY a resource?
-  → REST API via tfy-api.sh or curl
-
+```text
 Need to verify login?
-  → Check ~/.truefoundry/credentials.json (see prerequisites.md)
+  -> Check ~/.truefoundry/credentials.json (see prerequisites.md)
+
+Need to read/list/query gateway or platform resources?
+  -> Use the REST API via tfy-api.sh or curl
+
+Need kubeconfig?
+  -> tfy get kubeconfig
+
+Need to create/update resources from manifests?
+  -> tfy apply with dry-run/diff first, then explicit user confirmation
+
+Need to deploy or patch live applications?
+  -> tfy deploy / tfy patch-application only after workspace confirmation and user approval
+
+Need to delete, terminate, revoke, remove, or purge anything?
+  -> Do not run CLI/API destructive commands; provide manual dashboard steps
 ```

--- a/skills/_shared/references/prerequisites.md
+++ b/skills/_shared/references/prerequisites.md
@@ -2,16 +2,10 @@
 
 ## Step 0: CLI and Login Check
 
-Check if the TrueFoundry CLI is available:
+First check if the TrueFoundry CLI is available. This tells you whether the TrueFoundry Python package and `tfy` entrypoint are installed:
 
 ```bash
 tfy --version 2>/dev/null
-```
-
-If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
-
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
 ```
 
 If not found, install it:
@@ -20,9 +14,7 @@ If not found, install it:
 pip install 'truefoundry==0.5.0'
 ```
 
-> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
-
-Before any non-onboarding skill changes TrueFoundry resources, check that CLI login already exists:
+After `tfy --version` works, check whether CLI login already exists:
 
 ```bash
 python3 - <<'PY'
@@ -44,17 +36,38 @@ else:
 PY
 ```
 
+If login is missing, say:
+
+```text
+Looks like the tenant is not set or CLI login is not done.
+If you have not already, create an account at https://www.truefoundry.com/register, complete the onboarding/signup flow, and paste your tenant URL here.
+```
+
+Then use the onboard skill to run:
+
+```bash
+tfy login --host "<tenant-url>"
+```
+
+If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
+
+```bash
+export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
+```
+
+> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
+
 If the user does not have a TrueFoundry tenant or CLI login yet, stop and use the `truefoundry-onboard` skill. Do not duplicate onboarding steps in other skills.
 
 ## CLI Command Boundaries
 
-The `tfy` CLI only supports these subcommands:
+The current CLI surface is documented in `cli-reference.md`. Do not guess commands from common CLI patterns. If a command is not in `cli-reference.md`, run `tfy --help` or `tfy <subcommand> --help` before using it.
 
-- `tfy login` — authenticate
-- `tfy apply` — apply manifests
-- `tfy --version` — version check
+Common valid commands include `tfy login`, `tfy apply`, `tfy deploy`, `tfy get kubeconfig`, `tfy trigger job`, `tfy trigger workflow`, and `tfy ml download ...`.
 
-**These do NOT exist:** `tfy get`, `tfy config`, `tfy whoami`, `tfy list`, `tfy status`, `tfy download`, `tfy upload`. Do not probe for them. For any read operation, use the REST API via `tfy-api.sh`.
+Destructive commands such as `tfy delete` and `tfy terminate job` exist, but these skills must not execute them. Provide manual dashboard instructions instead.
+
+**These do NOT exist:** `tfy config`, `tfy show-config`, `tfy whoami`, `tfy list`, `tfy status`, top-level `tfy download`, and top-level `tfy upload`. Do not probe for them. For gateway/platform read operations, use the REST API via `tfy-api.sh`.
 
 ## Credential Check
 

--- a/skills/agents/references/cli-reference.md
+++ b/skills/agents/references/cli-reference.md
@@ -1,6 +1,10 @@
 # TrueFoundry CLI Reference
 
-The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for querying, listing, or inspecting resources. For read operations, use the REST API via `tfy-api.sh`.
+This reference is grounded in `tfy --help` from `tfy 0.13.12`.
+
+Do not guess `tfy` subcommands from common CLI patterns. Before using any `tfy` command not shown in this file, run `tfy --help` or `tfy <subcommand> --help` and use only commands that appear in that help output.
+
+For gateway/platform read operations, prefer the REST API via `tfy-api.sh`. The CLI has `tfy get kubeconfig`, but it does not provide general list/describe/status commands for TrueFoundry resources.
 
 ## Installation
 
@@ -8,127 +12,335 @@ The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for queryi
 pip install -U "truefoundry"
 ```
 
-Requires Python 3.9–3.14. Optional extras:
-- `pip install -U "truefoundry[workflow]"` — workflow support (Python 3.9–3.12)
-- `pip install -U "truefoundry[workflow,spark]"` — workflow + Spark
+Requires Python 3.9-3.14. Optional extras:
+- `pip install -U "truefoundry[workflow]"` - workflow support (Python 3.9-3.12)
+- `pip install -U "truefoundry[workflow,spark]"` - workflow + Spark
 
-## Commands
+## Global Options
 
-### tfy login
+| Command | Purpose |
+|---|---|
+| `tfy --version` | Print the installed CLI version. |
+| `tfy --json <command>` | Output entities in JSON format where the command supports entities. |
+| `tfy --debug <command>` | Enable debug logging. Can also be set with `TFY_DEBUG=1`. |
+| `tfy --help` / `tfy -h` | Show top-level help. |
+
+## Command Index
+
+| Command | Purpose | Skill usage guidance |
+|---|---|---|
+| `tfy apply` | Create/update resources from manifest files. | Allowed only after dry-run/diff plus explicit user confirmation. |
+| `tfy delete` | Delete resources. | Do not execute from skills; provide manual dashboard instructions instead. |
+| `tfy deploy` | Deploy an application from a `truefoundry.yaml` file. | Confirm workspace before use. |
+| `tfy deploy workflow` | Deploy a workflow file. | Confirm workspace before use. |
+| `tfy deploy-init model` | Generate model server application code for a model version. | Safe scaffolding command; still confirm output path. |
+| `tfy get kubeconfig` | Update kubeconfig for a TrueFoundry cluster. | Only CLI read-style command observed. |
+| `tfy login` | Login to a TrueFoundry tenant. | Valid onboarding command. |
+| `tfy logout` | Logout from the current session. | Do not run unless the user explicitly asks. |
+| `tfy ml download artifact` | Download a logged artifact version. | Writes files locally; confirm path/overwrite. |
+| `tfy ml download model` | Download a logged model version. | Writes files locally; confirm path/overwrite. |
+| `tfy patch` | Patch a local YAML file with a `yq` filter. | Local file mutation; review target file/output path first. |
+| `tfy patch-application` | Patch and deploy an existing application. | Deployment mutation; requires explicit user confirmation. |
+| `tfy terminate job` | Terminate a job run. | Do not execute from skills; destructive operational action. |
+| `tfy trigger job` | Trigger a job run asynchronously. | Ask before triggering; may start compute/cost. |
+| `tfy trigger workflow` | Trigger a workflow run. | Ask before triggering; may start compute/cost. |
+
+## Authentication
+
+### `tfy login`
 
 Authenticate the CLI against a TrueFoundry tenant.
 
 ```bash
-# Interactive (opens browser for device code flow) — recommended
+# Interactive login
 tfy login --host https://your-org.truefoundry.cloud
 
-# Non-interactive (CI/CD only — key appears in shell history)
+# Non-interactive login
 tfy login --host https://your-org.truefoundry.cloud --api-key "$TFY_API_KEY"
 ```
 
-Stores credentials in `~/.truefoundry/credentials.json`.
+Options:
+- `--host TEXT` - required tenant URL; can be set with `TFY_HOST`.
+- `--api-key TEXT` / `--api_key TEXT` - API key for non-interactive login.
+- `--relogin` - force relogin.
+- `--help` / `-h` - show command help.
 
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--host` | Yes | Tenant URL (e.g. `https://acme.truefoundry.cloud`) |
-| `--api-key` | No | API key for non-interactive login (CI/CD) |
+After `tfy login`, credentials are stored in:
 
-### tfy apply
-
-Create or update resources from YAML manifests.
-
-```bash
-# Single file
-tfy apply -f manifest.yaml
-
-# Multiple files
-tfy apply -f manifest1.yaml -f manifest2.yaml
-
-# Entire directory (recursive, discovers *.yaml and *.yml)
-tfy apply --dir ./manifests
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) to apply. Repeatable. |
-| `--dir <path>` | Directory of manifests (cannot combine with `-f`) |
-| `--dry-run` | Simulate changes without persisting |
-| `--show-diff` | Show diff between manifest and deployed state |
-| `--diffs-only` | Apply only changed files vs HEAD (requires `--dir`) |
-| `--ref <ref>` | Git ref to diff against (default: HEAD). Use with `--diffs-only` |
-| `--sync` | Delete platform resources for removed YAML files (requires `--dir` + `--diffs-only`) |
-
-**Supported resource types:** provider-account, gateway-load-balancing-config, gateway-rate-limiting-config, gateway-budget-config, gateway-guardrails-config, mcp-server, workspace, cluster, application, secret-group, ml-repo, agent, agent-skill
-
-**Environment:** Requires `TFY_HOST` to be set when `TFY_API_KEY` is in the environment:
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
-```
-
-### tfy delete
-
-Delete resources using the same manifest files used with `tfy apply`.
-
-```bash
-# Single file
-tfy delete -f manifest.yaml
-
-# Multiple files
-tfy delete -f manifest1.yaml -f manifest2.yaml
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) identifying resources to delete. Repeatable. |
-
-### tfy --version
-
-Print the installed CLI version.
-
-```bash
-tfy --version
-# Output: tfy version X.Y.Z
-```
-
-## Commands That DO NOT Exist
-
-The following are **not valid** `tfy` subcommands. Do not attempt them:
-
-- `tfy get` / `tfy list` / `tfy describe`
-- `tfy config` / `tfy config get` / `tfy config set`
-- `tfy whoami` / `tfy status`
-- `tfy download` / `tfy upload`
-- `tfy init` / `tfy create`
-- `tfy logs` / `tfy exec`
-
-For all read/query operations, use the REST API directly via `tfy-api.sh` or `curl`.
-
-## Authentication Modes
-
-| Mode | How | When |
-|------|-----|------|
-| Interactive login | `tfy login --host <url>` | Local development |
-| Environment variables | `TFY_HOST` + `TFY_API_KEY` | CI/CD, scripts, `tfy-api.sh` |
-| Non-interactive login | `tfy login --host <url> --api-key <key>` | CI/CD (key in history — prefer env vars) |
-
-## Credential Storage
-
-After `tfy login`, credentials are stored at:
-```
+```text
 ~/.truefoundry/credentials.json
 ```
 
-Fields: `host`, `access_token`, `refresh_token`.
+Fields include `host`, `access_token`, and `refresh_token`.
+
+### `tfy logout`
+
+Logout from the current TrueFoundry session.
+
+```bash
+tfy logout
+```
+
+Do not run this unless the user explicitly asks to logout.
+
+## Apply And Deploy
+
+### `tfy apply`
+
+Create or update resources from manifest files.
+
+```bash
+tfy apply -f manifest.yaml
+tfy apply -f manifest1.yaml -f manifest2.yaml
+tfy apply -f manifest.yaml --dry-run --show-diff
+```
+
+Options:
+- `--file FILE` / `-f FILE` - required manifest file. Repeat for multiple files.
+- `--dry-run` / `--dry_run` - simulate without applying.
+- `--show-diff` / `--show_diff` - print manifest differences when using `--dry-run`.
+- `--help` / `-h` - show command help.
+
+Before the final non-dry-run apply, show the target host/workspace, an English summary, the YAML or diff, the exact command, and wait for explicit user confirmation.
+
+### `tfy deploy`
+
+Deploy an application to TrueFoundry.
+
+```bash
+tfy deploy -f truefoundry.yaml -w "<workspace-fqn>"
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to `truefoundry.yaml`.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - workspace FQN. If omitted, the CLI reads it from the deployment spec when available.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--force` / `--no-force` - cancel ongoing deployments and force a new one. Defaults to no-force.
+- `--trigger-on-deploy` / `--trigger_on_deploy` / `--no-trigger-on-deploy` / `--no_trigger_on_deploy` - trigger a job run after deployment succeeds. No effect for non-job deployments.
+- `--help` / `-h` - show command help.
+
+Always confirm the workspace before deployment. Treat `--force` and trigger-on-deploy as higher-risk options requiring explicit user confirmation.
+
+### `tfy deploy workflow`
+
+Deploy a workflow file.
+
+```bash
+tfy deploy workflow --name "<workflow-name>" -f workflow.py -w "<workspace-fqn>"
+```
+
+Options:
+- `--name TEXT` / `-n TEXT` - required workflow name.
+- `--file FILE` / `-f FILE` - required workflow file.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - required workspace FQN.
+- `--help` / `-h` - show command help.
+
+### `tfy deploy-init model`
+
+Generate application code for a model server deployment.
+
+```bash
+tfy deploy-init model \
+  --name "<application-name>" \
+  --model-version-fqn "<model-version-fqn>" \
+  --workspace-fqn "<workspace-fqn>" \
+  --model-server fastapi \
+  --output-dir ./model-server
+```
+
+Options:
+- `--name APPLICATION-NAME` - required model server deployment name.
+- `--model-version-fqn NON-EMPTY-STRING` / `--model_version_fqn` - required model version FQN.
+- `--workspace-fqn NON-EMPTY-STRING` / `--workspace_fqn` / `-w` - required workspace FQN.
+- `--model-server [triton|fastapi]` / `--model_server` - model server type. Defaults to `fastapi`.
+- `--output-dir DIRECTORY` / `--output_dir` - output directory for generated code.
+- `--help` / `-h` - show command help.
+
+## Local Patching
+
+### `tfy patch`
+
+Patch a local YAML file with a `yq` filter.
+
+```bash
+tfy patch -f servicefoundry.yaml --filter '.image.image_uri = "repo/image:tag"' -o patched.yaml
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to servicefoundry YAML. Defaults to `./servicefoundry.yaml`.
+- `--filter TEXT` - required `yq` filter.
+- `--output-file PATH` / `-o PATH` - write output to a file.
+- `--indent INTEGER` / `-I INTEGER` - output indent. Defaults to `4`.
+- `--help` / `-h` - show command help.
+
+### `tfy patch-application`
+
+Patch and deploy an existing application.
+
+```bash
+tfy patch-application --application-fqn "<application-fqn>" --patch-file patch.yaml
+tfy patch-application --application-fqn "<application-fqn>" --patch '{"key":"value"}'
+```
+
+Options:
+- `--patch-file FILE` / `--patch_file FILE` / `-f FILE` - YAML patch file.
+- `--patch TEXT` / `-p TEXT` - JSON patch string.
+- `--application-fqn TEXT` / `--application_fqn TEXT` / `-a TEXT` - required application FQN.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--help` / `-h` - show command help.
+
+This mutates a live application. Show the patch and wait for explicit user confirmation before running.
+
+## Read-Style Commands
+
+### `tfy get kubeconfig`
+
+Update kubeconfig to access a cluster attached to the TrueFoundry Control Plane.
+
+```bash
+tfy get kubeconfig --cluster "<cluster-id>" --overwrite
+```
+
+Options:
+- `--cluster TEXT` / `-c TEXT` - cluster ID. If omitted, the CLI opens an interactive cluster picker.
+- `--overwrite` - overwrite an existing cluster entry without prompting.
+- `--help` / `-h` - show command help.
+
+This writes to `~/.kube/config` by default, or to the first path in `KUBECONFIG`.
+
+## Triggering Work
+
+### `tfy trigger job`
+
+Trigger a job asynchronously.
+
+```bash
+tfy trigger job --application-fqn "<cluster:workspace:job>"
+tfy trigger job --application-fqn "<cluster:workspace:job>" --command "python run.py"
+tfy trigger job --application-fqn "<cluster:workspace:job>" -- --param value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required job deployment FQN.
+- `--command TEXT` - command to run.
+- `--run-name-alias TEXT` / `--run_name_alias TEXT` - alias for the job run name.
+- `--help` / `-h` - show command help.
+
+Ask before triggering jobs because it can start compute and cost.
+
+### `tfy trigger workflow`
+
+Trigger a workflow.
+
+```bash
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>"
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>" -- --input value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required workflow application FQN.
+- `--help` / `-h` - show command help.
+
+Ask before triggering workflows because it can start compute and cost.
+
+## ML Downloads
+
+### `tfy ml download artifact`
+
+Download a logged artifact version.
+
+```bash
+tfy ml download artifact --fqn "<artifact-version-fqn>" --path ./downloads
+```
+
+Options:
+- `--fqn TEXT` - required artifact version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+### `tfy ml download model`
+
+Download a logged model version.
+
+```bash
+tfy ml download model --fqn "<model-version-fqn>" --path ./models
+```
+
+Options:
+- `--fqn TEXT` - required model version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+## Destructive Or Blocked Commands
+
+These commands exist in the CLI but must not be executed by these skills. Provide manual dashboard instructions instead.
+
+### `tfy delete`
+
+Delete TrueFoundry resources.
+
+Observed forms:
+- `tfy delete -f manifest.yaml`
+- `tfy delete application --application-fqn "<application-fqn>"`
+- `tfy delete workspace --workspace-fqn "<workspace-fqn>"`
+
+Options:
+- `--file FILE` / `-f FILE` - manifest file(s) identifying resources to delete.
+- `tfy delete application`: `--application-fqn TEXT` / `--application_fqn TEXT`, `--yes`.
+- `tfy delete workspace`: `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT`, `--yes`.
+
+### `tfy terminate job`
+
+Terminate a job run.
+
+```bash
+tfy terminate job --job-fqn "<job-fqn>" --job-run-name "<run-name>"
+```
+
+Options:
+- `--job-fqn TEXT` / `--job_fqn TEXT` - required job FQN.
+- `--job-run-name TEXT` / `--job_run_name TEXT` - required run name.
+- `--help` / `-h` - show command help.
+
+## Commands That Do Not Exist In `tfy 0.13.12`
+
+The following are not valid `tfy` commands. Do not attempt them:
+
+- `tfy whoami`
+- `tfy show-config`
+- `tfy status`
+- `tfy config`, `tfy config get`, `tfy config set`
+- `tfy list`
+- `tfy describe`
+- `tfy logs`
+- `tfy exec`
+- `tfy init`
+- `tfy create`
+- `tfy ask`
+- top-level `tfy download` or `tfy upload` (`tfy ml download ...` is valid)
 
 ## Decision Tree
 
-```
-Need to CREATE/UPDATE/DELETE a resource?
-  → tfy apply / tfy delete
-
-Need to READ/LIST/QUERY a resource?
-  → REST API via tfy-api.sh or curl
-
+```text
 Need to verify login?
-  → Check ~/.truefoundry/credentials.json (see prerequisites.md)
+  -> Check ~/.truefoundry/credentials.json (see prerequisites.md)
+
+Need to read/list/query gateway or platform resources?
+  -> Use the REST API via tfy-api.sh or curl
+
+Need kubeconfig?
+  -> tfy get kubeconfig
+
+Need to create/update resources from manifests?
+  -> tfy apply with dry-run/diff first, then explicit user confirmation
+
+Need to deploy or patch live applications?
+  -> tfy deploy / tfy patch-application only after workspace confirmation and user approval
+
+Need to delete, terminate, revoke, remove, or purge anything?
+  -> Do not run CLI/API destructive commands; provide manual dashboard steps
 ```

--- a/skills/agents/references/prerequisites.md
+++ b/skills/agents/references/prerequisites.md
@@ -2,16 +2,10 @@
 
 ## Step 0: CLI and Login Check
 
-Check if the TrueFoundry CLI is available:
+First check if the TrueFoundry CLI is available. This tells you whether the TrueFoundry Python package and `tfy` entrypoint are installed:
 
 ```bash
 tfy --version 2>/dev/null
-```
-
-If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
-
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
 ```
 
 If not found, install it:
@@ -20,9 +14,7 @@ If not found, install it:
 pip install 'truefoundry==0.5.0'
 ```
 
-> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
-
-Before any non-onboarding skill changes TrueFoundry resources, check that CLI login already exists:
+After `tfy --version` works, check whether CLI login already exists:
 
 ```bash
 python3 - <<'PY'
@@ -44,17 +36,38 @@ else:
 PY
 ```
 
+If login is missing, say:
+
+```text
+Looks like the tenant is not set or CLI login is not done.
+If you have not already, create an account at https://www.truefoundry.com/register, complete the onboarding/signup flow, and paste your tenant URL here.
+```
+
+Then use the onboard skill to run:
+
+```bash
+tfy login --host "<tenant-url>"
+```
+
+If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
+
+```bash
+export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
+```
+
+> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
+
 If the user does not have a TrueFoundry tenant or CLI login yet, stop and use the `truefoundry-onboard` skill. Do not duplicate onboarding steps in other skills.
 
 ## CLI Command Boundaries
 
-The `tfy` CLI only supports these subcommands:
+The current CLI surface is documented in `cli-reference.md`. Do not guess commands from common CLI patterns. If a command is not in `cli-reference.md`, run `tfy --help` or `tfy <subcommand> --help` before using it.
 
-- `tfy login` — authenticate
-- `tfy apply` — apply manifests
-- `tfy --version` — version check
+Common valid commands include `tfy login`, `tfy apply`, `tfy deploy`, `tfy get kubeconfig`, `tfy trigger job`, `tfy trigger workflow`, and `tfy ml download ...`.
 
-**These do NOT exist:** `tfy get`, `tfy config`, `tfy whoami`, `tfy list`, `tfy status`, `tfy download`, `tfy upload`. Do not probe for them. For any read operation, use the REST API via `tfy-api.sh`.
+Destructive commands such as `tfy delete` and `tfy terminate job` exist, but these skills must not execute them. Provide manual dashboard instructions instead.
+
+**These do NOT exist:** `tfy config`, `tfy show-config`, `tfy whoami`, `tfy list`, `tfy status`, top-level `tfy download`, and top-level `tfy upload`. Do not probe for them. For gateway/platform read operations, use the REST API via `tfy-api.sh`.
 
 ## Credential Check
 

--- a/skills/gateway/references/cli-reference.md
+++ b/skills/gateway/references/cli-reference.md
@@ -1,6 +1,10 @@
 # TrueFoundry CLI Reference
 
-The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for querying, listing, or inspecting resources. For read operations, use the REST API via `tfy-api.sh`.
+This reference is grounded in `tfy --help` from `tfy 0.13.12`.
+
+Do not guess `tfy` subcommands from common CLI patterns. Before using any `tfy` command not shown in this file, run `tfy --help` or `tfy <subcommand> --help` and use only commands that appear in that help output.
+
+For gateway/platform read operations, prefer the REST API via `tfy-api.sh`. The CLI has `tfy get kubeconfig`, but it does not provide general list/describe/status commands for TrueFoundry resources.
 
 ## Installation
 
@@ -8,127 +12,335 @@ The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for queryi
 pip install -U "truefoundry"
 ```
 
-Requires Python 3.9–3.14. Optional extras:
-- `pip install -U "truefoundry[workflow]"` — workflow support (Python 3.9–3.12)
-- `pip install -U "truefoundry[workflow,spark]"` — workflow + Spark
+Requires Python 3.9-3.14. Optional extras:
+- `pip install -U "truefoundry[workflow]"` - workflow support (Python 3.9-3.12)
+- `pip install -U "truefoundry[workflow,spark]"` - workflow + Spark
 
-## Commands
+## Global Options
 
-### tfy login
+| Command | Purpose |
+|---|---|
+| `tfy --version` | Print the installed CLI version. |
+| `tfy --json <command>` | Output entities in JSON format where the command supports entities. |
+| `tfy --debug <command>` | Enable debug logging. Can also be set with `TFY_DEBUG=1`. |
+| `tfy --help` / `tfy -h` | Show top-level help. |
+
+## Command Index
+
+| Command | Purpose | Skill usage guidance |
+|---|---|---|
+| `tfy apply` | Create/update resources from manifest files. | Allowed only after dry-run/diff plus explicit user confirmation. |
+| `tfy delete` | Delete resources. | Do not execute from skills; provide manual dashboard instructions instead. |
+| `tfy deploy` | Deploy an application from a `truefoundry.yaml` file. | Confirm workspace before use. |
+| `tfy deploy workflow` | Deploy a workflow file. | Confirm workspace before use. |
+| `tfy deploy-init model` | Generate model server application code for a model version. | Safe scaffolding command; still confirm output path. |
+| `tfy get kubeconfig` | Update kubeconfig for a TrueFoundry cluster. | Only CLI read-style command observed. |
+| `tfy login` | Login to a TrueFoundry tenant. | Valid onboarding command. |
+| `tfy logout` | Logout from the current session. | Do not run unless the user explicitly asks. |
+| `tfy ml download artifact` | Download a logged artifact version. | Writes files locally; confirm path/overwrite. |
+| `tfy ml download model` | Download a logged model version. | Writes files locally; confirm path/overwrite. |
+| `tfy patch` | Patch a local YAML file with a `yq` filter. | Local file mutation; review target file/output path first. |
+| `tfy patch-application` | Patch and deploy an existing application. | Deployment mutation; requires explicit user confirmation. |
+| `tfy terminate job` | Terminate a job run. | Do not execute from skills; destructive operational action. |
+| `tfy trigger job` | Trigger a job run asynchronously. | Ask before triggering; may start compute/cost. |
+| `tfy trigger workflow` | Trigger a workflow run. | Ask before triggering; may start compute/cost. |
+
+## Authentication
+
+### `tfy login`
 
 Authenticate the CLI against a TrueFoundry tenant.
 
 ```bash
-# Interactive (opens browser for device code flow) — recommended
+# Interactive login
 tfy login --host https://your-org.truefoundry.cloud
 
-# Non-interactive (CI/CD only — key appears in shell history)
+# Non-interactive login
 tfy login --host https://your-org.truefoundry.cloud --api-key "$TFY_API_KEY"
 ```
 
-Stores credentials in `~/.truefoundry/credentials.json`.
+Options:
+- `--host TEXT` - required tenant URL; can be set with `TFY_HOST`.
+- `--api-key TEXT` / `--api_key TEXT` - API key for non-interactive login.
+- `--relogin` - force relogin.
+- `--help` / `-h` - show command help.
 
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--host` | Yes | Tenant URL (e.g. `https://acme.truefoundry.cloud`) |
-| `--api-key` | No | API key for non-interactive login (CI/CD) |
+After `tfy login`, credentials are stored in:
 
-### tfy apply
-
-Create or update resources from YAML manifests.
-
-```bash
-# Single file
-tfy apply -f manifest.yaml
-
-# Multiple files
-tfy apply -f manifest1.yaml -f manifest2.yaml
-
-# Entire directory (recursive, discovers *.yaml and *.yml)
-tfy apply --dir ./manifests
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) to apply. Repeatable. |
-| `--dir <path>` | Directory of manifests (cannot combine with `-f`) |
-| `--dry-run` | Simulate changes without persisting |
-| `--show-diff` | Show diff between manifest and deployed state |
-| `--diffs-only` | Apply only changed files vs HEAD (requires `--dir`) |
-| `--ref <ref>` | Git ref to diff against (default: HEAD). Use with `--diffs-only` |
-| `--sync` | Delete platform resources for removed YAML files (requires `--dir` + `--diffs-only`) |
-
-**Supported resource types:** provider-account, gateway-load-balancing-config, gateway-rate-limiting-config, gateway-budget-config, gateway-guardrails-config, mcp-server, workspace, cluster, application, secret-group, ml-repo, agent, agent-skill
-
-**Environment:** Requires `TFY_HOST` to be set when `TFY_API_KEY` is in the environment:
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
-```
-
-### tfy delete
-
-Delete resources using the same manifest files used with `tfy apply`.
-
-```bash
-# Single file
-tfy delete -f manifest.yaml
-
-# Multiple files
-tfy delete -f manifest1.yaml -f manifest2.yaml
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) identifying resources to delete. Repeatable. |
-
-### tfy --version
-
-Print the installed CLI version.
-
-```bash
-tfy --version
-# Output: tfy version X.Y.Z
-```
-
-## Commands That DO NOT Exist
-
-The following are **not valid** `tfy` subcommands. Do not attempt them:
-
-- `tfy get` / `tfy list` / `tfy describe`
-- `tfy config` / `tfy config get` / `tfy config set`
-- `tfy whoami` / `tfy status`
-- `tfy download` / `tfy upload`
-- `tfy init` / `tfy create`
-- `tfy logs` / `tfy exec`
-
-For all read/query operations, use the REST API directly via `tfy-api.sh` or `curl`.
-
-## Authentication Modes
-
-| Mode | How | When |
-|------|-----|------|
-| Interactive login | `tfy login --host <url>` | Local development |
-| Environment variables | `TFY_HOST` + `TFY_API_KEY` | CI/CD, scripts, `tfy-api.sh` |
-| Non-interactive login | `tfy login --host <url> --api-key <key>` | CI/CD (key in history — prefer env vars) |
-
-## Credential Storage
-
-After `tfy login`, credentials are stored at:
-```
+```text
 ~/.truefoundry/credentials.json
 ```
 
-Fields: `host`, `access_token`, `refresh_token`.
+Fields include `host`, `access_token`, and `refresh_token`.
+
+### `tfy logout`
+
+Logout from the current TrueFoundry session.
+
+```bash
+tfy logout
+```
+
+Do not run this unless the user explicitly asks to logout.
+
+## Apply And Deploy
+
+### `tfy apply`
+
+Create or update resources from manifest files.
+
+```bash
+tfy apply -f manifest.yaml
+tfy apply -f manifest1.yaml -f manifest2.yaml
+tfy apply -f manifest.yaml --dry-run --show-diff
+```
+
+Options:
+- `--file FILE` / `-f FILE` - required manifest file. Repeat for multiple files.
+- `--dry-run` / `--dry_run` - simulate without applying.
+- `--show-diff` / `--show_diff` - print manifest differences when using `--dry-run`.
+- `--help` / `-h` - show command help.
+
+Before the final non-dry-run apply, show the target host/workspace, an English summary, the YAML or diff, the exact command, and wait for explicit user confirmation.
+
+### `tfy deploy`
+
+Deploy an application to TrueFoundry.
+
+```bash
+tfy deploy -f truefoundry.yaml -w "<workspace-fqn>"
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to `truefoundry.yaml`.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - workspace FQN. If omitted, the CLI reads it from the deployment spec when available.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--force` / `--no-force` - cancel ongoing deployments and force a new one. Defaults to no-force.
+- `--trigger-on-deploy` / `--trigger_on_deploy` / `--no-trigger-on-deploy` / `--no_trigger_on_deploy` - trigger a job run after deployment succeeds. No effect for non-job deployments.
+- `--help` / `-h` - show command help.
+
+Always confirm the workspace before deployment. Treat `--force` and trigger-on-deploy as higher-risk options requiring explicit user confirmation.
+
+### `tfy deploy workflow`
+
+Deploy a workflow file.
+
+```bash
+tfy deploy workflow --name "<workflow-name>" -f workflow.py -w "<workspace-fqn>"
+```
+
+Options:
+- `--name TEXT` / `-n TEXT` - required workflow name.
+- `--file FILE` / `-f FILE` - required workflow file.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - required workspace FQN.
+- `--help` / `-h` - show command help.
+
+### `tfy deploy-init model`
+
+Generate application code for a model server deployment.
+
+```bash
+tfy deploy-init model \
+  --name "<application-name>" \
+  --model-version-fqn "<model-version-fqn>" \
+  --workspace-fqn "<workspace-fqn>" \
+  --model-server fastapi \
+  --output-dir ./model-server
+```
+
+Options:
+- `--name APPLICATION-NAME` - required model server deployment name.
+- `--model-version-fqn NON-EMPTY-STRING` / `--model_version_fqn` - required model version FQN.
+- `--workspace-fqn NON-EMPTY-STRING` / `--workspace_fqn` / `-w` - required workspace FQN.
+- `--model-server [triton|fastapi]` / `--model_server` - model server type. Defaults to `fastapi`.
+- `--output-dir DIRECTORY` / `--output_dir` - output directory for generated code.
+- `--help` / `-h` - show command help.
+
+## Local Patching
+
+### `tfy patch`
+
+Patch a local YAML file with a `yq` filter.
+
+```bash
+tfy patch -f servicefoundry.yaml --filter '.image.image_uri = "repo/image:tag"' -o patched.yaml
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to servicefoundry YAML. Defaults to `./servicefoundry.yaml`.
+- `--filter TEXT` - required `yq` filter.
+- `--output-file PATH` / `-o PATH` - write output to a file.
+- `--indent INTEGER` / `-I INTEGER` - output indent. Defaults to `4`.
+- `--help` / `-h` - show command help.
+
+### `tfy patch-application`
+
+Patch and deploy an existing application.
+
+```bash
+tfy patch-application --application-fqn "<application-fqn>" --patch-file patch.yaml
+tfy patch-application --application-fqn "<application-fqn>" --patch '{"key":"value"}'
+```
+
+Options:
+- `--patch-file FILE` / `--patch_file FILE` / `-f FILE` - YAML patch file.
+- `--patch TEXT` / `-p TEXT` - JSON patch string.
+- `--application-fqn TEXT` / `--application_fqn TEXT` / `-a TEXT` - required application FQN.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--help` / `-h` - show command help.
+
+This mutates a live application. Show the patch and wait for explicit user confirmation before running.
+
+## Read-Style Commands
+
+### `tfy get kubeconfig`
+
+Update kubeconfig to access a cluster attached to the TrueFoundry Control Plane.
+
+```bash
+tfy get kubeconfig --cluster "<cluster-id>" --overwrite
+```
+
+Options:
+- `--cluster TEXT` / `-c TEXT` - cluster ID. If omitted, the CLI opens an interactive cluster picker.
+- `--overwrite` - overwrite an existing cluster entry without prompting.
+- `--help` / `-h` - show command help.
+
+This writes to `~/.kube/config` by default, or to the first path in `KUBECONFIG`.
+
+## Triggering Work
+
+### `tfy trigger job`
+
+Trigger a job asynchronously.
+
+```bash
+tfy trigger job --application-fqn "<cluster:workspace:job>"
+tfy trigger job --application-fqn "<cluster:workspace:job>" --command "python run.py"
+tfy trigger job --application-fqn "<cluster:workspace:job>" -- --param value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required job deployment FQN.
+- `--command TEXT` - command to run.
+- `--run-name-alias TEXT` / `--run_name_alias TEXT` - alias for the job run name.
+- `--help` / `-h` - show command help.
+
+Ask before triggering jobs because it can start compute and cost.
+
+### `tfy trigger workflow`
+
+Trigger a workflow.
+
+```bash
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>"
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>" -- --input value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required workflow application FQN.
+- `--help` / `-h` - show command help.
+
+Ask before triggering workflows because it can start compute and cost.
+
+## ML Downloads
+
+### `tfy ml download artifact`
+
+Download a logged artifact version.
+
+```bash
+tfy ml download artifact --fqn "<artifact-version-fqn>" --path ./downloads
+```
+
+Options:
+- `--fqn TEXT` - required artifact version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+### `tfy ml download model`
+
+Download a logged model version.
+
+```bash
+tfy ml download model --fqn "<model-version-fqn>" --path ./models
+```
+
+Options:
+- `--fqn TEXT` - required model version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+## Destructive Or Blocked Commands
+
+These commands exist in the CLI but must not be executed by these skills. Provide manual dashboard instructions instead.
+
+### `tfy delete`
+
+Delete TrueFoundry resources.
+
+Observed forms:
+- `tfy delete -f manifest.yaml`
+- `tfy delete application --application-fqn "<application-fqn>"`
+- `tfy delete workspace --workspace-fqn "<workspace-fqn>"`
+
+Options:
+- `--file FILE` / `-f FILE` - manifest file(s) identifying resources to delete.
+- `tfy delete application`: `--application-fqn TEXT` / `--application_fqn TEXT`, `--yes`.
+- `tfy delete workspace`: `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT`, `--yes`.
+
+### `tfy terminate job`
+
+Terminate a job run.
+
+```bash
+tfy terminate job --job-fqn "<job-fqn>" --job-run-name "<run-name>"
+```
+
+Options:
+- `--job-fqn TEXT` / `--job_fqn TEXT` - required job FQN.
+- `--job-run-name TEXT` / `--job_run_name TEXT` - required run name.
+- `--help` / `-h` - show command help.
+
+## Commands That Do Not Exist In `tfy 0.13.12`
+
+The following are not valid `tfy` commands. Do not attempt them:
+
+- `tfy whoami`
+- `tfy show-config`
+- `tfy status`
+- `tfy config`, `tfy config get`, `tfy config set`
+- `tfy list`
+- `tfy describe`
+- `tfy logs`
+- `tfy exec`
+- `tfy init`
+- `tfy create`
+- `tfy ask`
+- top-level `tfy download` or `tfy upload` (`tfy ml download ...` is valid)
 
 ## Decision Tree
 
-```
-Need to CREATE/UPDATE/DELETE a resource?
-  → tfy apply / tfy delete
-
-Need to READ/LIST/QUERY a resource?
-  → REST API via tfy-api.sh or curl
-
+```text
 Need to verify login?
-  → Check ~/.truefoundry/credentials.json (see prerequisites.md)
+  -> Check ~/.truefoundry/credentials.json (see prerequisites.md)
+
+Need to read/list/query gateway or platform resources?
+  -> Use the REST API via tfy-api.sh or curl
+
+Need kubeconfig?
+  -> tfy get kubeconfig
+
+Need to create/update resources from manifests?
+  -> tfy apply with dry-run/diff first, then explicit user confirmation
+
+Need to deploy or patch live applications?
+  -> tfy deploy / tfy patch-application only after workspace confirmation and user approval
+
+Need to delete, terminate, revoke, remove, or purge anything?
+  -> Do not run CLI/API destructive commands; provide manual dashboard steps
 ```

--- a/skills/gateway/references/prerequisites.md
+++ b/skills/gateway/references/prerequisites.md
@@ -2,16 +2,10 @@
 
 ## Step 0: CLI and Login Check
 
-Check if the TrueFoundry CLI is available:
+First check if the TrueFoundry CLI is available. This tells you whether the TrueFoundry Python package and `tfy` entrypoint are installed:
 
 ```bash
 tfy --version 2>/dev/null
-```
-
-If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
-
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
 ```
 
 If not found, install it:
@@ -20,9 +14,7 @@ If not found, install it:
 pip install 'truefoundry==0.5.0'
 ```
 
-> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
-
-Before any non-onboarding skill changes TrueFoundry resources, check that CLI login already exists:
+After `tfy --version` works, check whether CLI login already exists:
 
 ```bash
 python3 - <<'PY'
@@ -44,17 +36,38 @@ else:
 PY
 ```
 
+If login is missing, say:
+
+```text
+Looks like the tenant is not set or CLI login is not done.
+If you have not already, create an account at https://www.truefoundry.com/register, complete the onboarding/signup flow, and paste your tenant URL here.
+```
+
+Then use the onboard skill to run:
+
+```bash
+tfy login --host "<tenant-url>"
+```
+
+If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
+
+```bash
+export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
+```
+
+> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
+
 If the user does not have a TrueFoundry tenant or CLI login yet, stop and use the `truefoundry-onboard` skill. Do not duplicate onboarding steps in other skills.
 
 ## CLI Command Boundaries
 
-The `tfy` CLI only supports these subcommands:
+The current CLI surface is documented in `cli-reference.md`. Do not guess commands from common CLI patterns. If a command is not in `cli-reference.md`, run `tfy --help` or `tfy <subcommand> --help` before using it.
 
-- `tfy login` — authenticate
-- `tfy apply` — apply manifests
-- `tfy --version` — version check
+Common valid commands include `tfy login`, `tfy apply`, `tfy deploy`, `tfy get kubeconfig`, `tfy trigger job`, `tfy trigger workflow`, and `tfy ml download ...`.
 
-**These do NOT exist:** `tfy get`, `tfy config`, `tfy whoami`, `tfy list`, `tfy status`, `tfy download`, `tfy upload`. Do not probe for them. For any read operation, use the REST API via `tfy-api.sh`.
+Destructive commands such as `tfy delete` and `tfy terminate job` exist, but these skills must not execute them. Provide manual dashboard instructions instead.
+
+**These do NOT exist:** `tfy config`, `tfy show-config`, `tfy whoami`, `tfy list`, `tfy status`, top-level `tfy download`, and top-level `tfy upload`. Do not probe for them. For gateway/platform read operations, use the REST API via `tfy-api.sh`.
 
 ## Credential Check
 

--- a/skills/integrate-gateway/references/cli-reference.md
+++ b/skills/integrate-gateway/references/cli-reference.md
@@ -1,6 +1,10 @@
 # TrueFoundry CLI Reference
 
-The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for querying, listing, or inspecting resources. For read operations, use the REST API via `tfy-api.sh`.
+This reference is grounded in `tfy --help` from `tfy 0.13.12`.
+
+Do not guess `tfy` subcommands from common CLI patterns. Before using any `tfy` command not shown in this file, run `tfy --help` or `tfy <subcommand> --help` and use only commands that appear in that help output.
+
+For gateway/platform read operations, prefer the REST API via `tfy-api.sh`. The CLI has `tfy get kubeconfig`, but it does not provide general list/describe/status commands for TrueFoundry resources.
 
 ## Installation
 
@@ -8,127 +12,335 @@ The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for queryi
 pip install -U "truefoundry"
 ```
 
-Requires Python 3.9–3.14. Optional extras:
-- `pip install -U "truefoundry[workflow]"` — workflow support (Python 3.9–3.12)
-- `pip install -U "truefoundry[workflow,spark]"` — workflow + Spark
+Requires Python 3.9-3.14. Optional extras:
+- `pip install -U "truefoundry[workflow]"` - workflow support (Python 3.9-3.12)
+- `pip install -U "truefoundry[workflow,spark]"` - workflow + Spark
 
-## Commands
+## Global Options
 
-### tfy login
+| Command | Purpose |
+|---|---|
+| `tfy --version` | Print the installed CLI version. |
+| `tfy --json <command>` | Output entities in JSON format where the command supports entities. |
+| `tfy --debug <command>` | Enable debug logging. Can also be set with `TFY_DEBUG=1`. |
+| `tfy --help` / `tfy -h` | Show top-level help. |
+
+## Command Index
+
+| Command | Purpose | Skill usage guidance |
+|---|---|---|
+| `tfy apply` | Create/update resources from manifest files. | Allowed only after dry-run/diff plus explicit user confirmation. |
+| `tfy delete` | Delete resources. | Do not execute from skills; provide manual dashboard instructions instead. |
+| `tfy deploy` | Deploy an application from a `truefoundry.yaml` file. | Confirm workspace before use. |
+| `tfy deploy workflow` | Deploy a workflow file. | Confirm workspace before use. |
+| `tfy deploy-init model` | Generate model server application code for a model version. | Safe scaffolding command; still confirm output path. |
+| `tfy get kubeconfig` | Update kubeconfig for a TrueFoundry cluster. | Only CLI read-style command observed. |
+| `tfy login` | Login to a TrueFoundry tenant. | Valid onboarding command. |
+| `tfy logout` | Logout from the current session. | Do not run unless the user explicitly asks. |
+| `tfy ml download artifact` | Download a logged artifact version. | Writes files locally; confirm path/overwrite. |
+| `tfy ml download model` | Download a logged model version. | Writes files locally; confirm path/overwrite. |
+| `tfy patch` | Patch a local YAML file with a `yq` filter. | Local file mutation; review target file/output path first. |
+| `tfy patch-application` | Patch and deploy an existing application. | Deployment mutation; requires explicit user confirmation. |
+| `tfy terminate job` | Terminate a job run. | Do not execute from skills; destructive operational action. |
+| `tfy trigger job` | Trigger a job run asynchronously. | Ask before triggering; may start compute/cost. |
+| `tfy trigger workflow` | Trigger a workflow run. | Ask before triggering; may start compute/cost. |
+
+## Authentication
+
+### `tfy login`
 
 Authenticate the CLI against a TrueFoundry tenant.
 
 ```bash
-# Interactive (opens browser for device code flow) — recommended
+# Interactive login
 tfy login --host https://your-org.truefoundry.cloud
 
-# Non-interactive (CI/CD only — key appears in shell history)
+# Non-interactive login
 tfy login --host https://your-org.truefoundry.cloud --api-key "$TFY_API_KEY"
 ```
 
-Stores credentials in `~/.truefoundry/credentials.json`.
+Options:
+- `--host TEXT` - required tenant URL; can be set with `TFY_HOST`.
+- `--api-key TEXT` / `--api_key TEXT` - API key for non-interactive login.
+- `--relogin` - force relogin.
+- `--help` / `-h` - show command help.
 
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--host` | Yes | Tenant URL (e.g. `https://acme.truefoundry.cloud`) |
-| `--api-key` | No | API key for non-interactive login (CI/CD) |
+After `tfy login`, credentials are stored in:
 
-### tfy apply
-
-Create or update resources from YAML manifests.
-
-```bash
-# Single file
-tfy apply -f manifest.yaml
-
-# Multiple files
-tfy apply -f manifest1.yaml -f manifest2.yaml
-
-# Entire directory (recursive, discovers *.yaml and *.yml)
-tfy apply --dir ./manifests
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) to apply. Repeatable. |
-| `--dir <path>` | Directory of manifests (cannot combine with `-f`) |
-| `--dry-run` | Simulate changes without persisting |
-| `--show-diff` | Show diff between manifest and deployed state |
-| `--diffs-only` | Apply only changed files vs HEAD (requires `--dir`) |
-| `--ref <ref>` | Git ref to diff against (default: HEAD). Use with `--diffs-only` |
-| `--sync` | Delete platform resources for removed YAML files (requires `--dir` + `--diffs-only`) |
-
-**Supported resource types:** provider-account, gateway-load-balancing-config, gateway-rate-limiting-config, gateway-budget-config, gateway-guardrails-config, mcp-server, workspace, cluster, application, secret-group, ml-repo, agent, agent-skill
-
-**Environment:** Requires `TFY_HOST` to be set when `TFY_API_KEY` is in the environment:
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
-```
-
-### tfy delete
-
-Delete resources using the same manifest files used with `tfy apply`.
-
-```bash
-# Single file
-tfy delete -f manifest.yaml
-
-# Multiple files
-tfy delete -f manifest1.yaml -f manifest2.yaml
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) identifying resources to delete. Repeatable. |
-
-### tfy --version
-
-Print the installed CLI version.
-
-```bash
-tfy --version
-# Output: tfy version X.Y.Z
-```
-
-## Commands That DO NOT Exist
-
-The following are **not valid** `tfy` subcommands. Do not attempt them:
-
-- `tfy get` / `tfy list` / `tfy describe`
-- `tfy config` / `tfy config get` / `tfy config set`
-- `tfy whoami` / `tfy status`
-- `tfy download` / `tfy upload`
-- `tfy init` / `tfy create`
-- `tfy logs` / `tfy exec`
-
-For all read/query operations, use the REST API directly via `tfy-api.sh` or `curl`.
-
-## Authentication Modes
-
-| Mode | How | When |
-|------|-----|------|
-| Interactive login | `tfy login --host <url>` | Local development |
-| Environment variables | `TFY_HOST` + `TFY_API_KEY` | CI/CD, scripts, `tfy-api.sh` |
-| Non-interactive login | `tfy login --host <url> --api-key <key>` | CI/CD (key in history — prefer env vars) |
-
-## Credential Storage
-
-After `tfy login`, credentials are stored at:
-```
+```text
 ~/.truefoundry/credentials.json
 ```
 
-Fields: `host`, `access_token`, `refresh_token`.
+Fields include `host`, `access_token`, and `refresh_token`.
+
+### `tfy logout`
+
+Logout from the current TrueFoundry session.
+
+```bash
+tfy logout
+```
+
+Do not run this unless the user explicitly asks to logout.
+
+## Apply And Deploy
+
+### `tfy apply`
+
+Create or update resources from manifest files.
+
+```bash
+tfy apply -f manifest.yaml
+tfy apply -f manifest1.yaml -f manifest2.yaml
+tfy apply -f manifest.yaml --dry-run --show-diff
+```
+
+Options:
+- `--file FILE` / `-f FILE` - required manifest file. Repeat for multiple files.
+- `--dry-run` / `--dry_run` - simulate without applying.
+- `--show-diff` / `--show_diff` - print manifest differences when using `--dry-run`.
+- `--help` / `-h` - show command help.
+
+Before the final non-dry-run apply, show the target host/workspace, an English summary, the YAML or diff, the exact command, and wait for explicit user confirmation.
+
+### `tfy deploy`
+
+Deploy an application to TrueFoundry.
+
+```bash
+tfy deploy -f truefoundry.yaml -w "<workspace-fqn>"
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to `truefoundry.yaml`.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - workspace FQN. If omitted, the CLI reads it from the deployment spec when available.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--force` / `--no-force` - cancel ongoing deployments and force a new one. Defaults to no-force.
+- `--trigger-on-deploy` / `--trigger_on_deploy` / `--no-trigger-on-deploy` / `--no_trigger_on_deploy` - trigger a job run after deployment succeeds. No effect for non-job deployments.
+- `--help` / `-h` - show command help.
+
+Always confirm the workspace before deployment. Treat `--force` and trigger-on-deploy as higher-risk options requiring explicit user confirmation.
+
+### `tfy deploy workflow`
+
+Deploy a workflow file.
+
+```bash
+tfy deploy workflow --name "<workflow-name>" -f workflow.py -w "<workspace-fqn>"
+```
+
+Options:
+- `--name TEXT` / `-n TEXT` - required workflow name.
+- `--file FILE` / `-f FILE` - required workflow file.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - required workspace FQN.
+- `--help` / `-h` - show command help.
+
+### `tfy deploy-init model`
+
+Generate application code for a model server deployment.
+
+```bash
+tfy deploy-init model \
+  --name "<application-name>" \
+  --model-version-fqn "<model-version-fqn>" \
+  --workspace-fqn "<workspace-fqn>" \
+  --model-server fastapi \
+  --output-dir ./model-server
+```
+
+Options:
+- `--name APPLICATION-NAME` - required model server deployment name.
+- `--model-version-fqn NON-EMPTY-STRING` / `--model_version_fqn` - required model version FQN.
+- `--workspace-fqn NON-EMPTY-STRING` / `--workspace_fqn` / `-w` - required workspace FQN.
+- `--model-server [triton|fastapi]` / `--model_server` - model server type. Defaults to `fastapi`.
+- `--output-dir DIRECTORY` / `--output_dir` - output directory for generated code.
+- `--help` / `-h` - show command help.
+
+## Local Patching
+
+### `tfy patch`
+
+Patch a local YAML file with a `yq` filter.
+
+```bash
+tfy patch -f servicefoundry.yaml --filter '.image.image_uri = "repo/image:tag"' -o patched.yaml
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to servicefoundry YAML. Defaults to `./servicefoundry.yaml`.
+- `--filter TEXT` - required `yq` filter.
+- `--output-file PATH` / `-o PATH` - write output to a file.
+- `--indent INTEGER` / `-I INTEGER` - output indent. Defaults to `4`.
+- `--help` / `-h` - show command help.
+
+### `tfy patch-application`
+
+Patch and deploy an existing application.
+
+```bash
+tfy patch-application --application-fqn "<application-fqn>" --patch-file patch.yaml
+tfy patch-application --application-fqn "<application-fqn>" --patch '{"key":"value"}'
+```
+
+Options:
+- `--patch-file FILE` / `--patch_file FILE` / `-f FILE` - YAML patch file.
+- `--patch TEXT` / `-p TEXT` - JSON patch string.
+- `--application-fqn TEXT` / `--application_fqn TEXT` / `-a TEXT` - required application FQN.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--help` / `-h` - show command help.
+
+This mutates a live application. Show the patch and wait for explicit user confirmation before running.
+
+## Read-Style Commands
+
+### `tfy get kubeconfig`
+
+Update kubeconfig to access a cluster attached to the TrueFoundry Control Plane.
+
+```bash
+tfy get kubeconfig --cluster "<cluster-id>" --overwrite
+```
+
+Options:
+- `--cluster TEXT` / `-c TEXT` - cluster ID. If omitted, the CLI opens an interactive cluster picker.
+- `--overwrite` - overwrite an existing cluster entry without prompting.
+- `--help` / `-h` - show command help.
+
+This writes to `~/.kube/config` by default, or to the first path in `KUBECONFIG`.
+
+## Triggering Work
+
+### `tfy trigger job`
+
+Trigger a job asynchronously.
+
+```bash
+tfy trigger job --application-fqn "<cluster:workspace:job>"
+tfy trigger job --application-fqn "<cluster:workspace:job>" --command "python run.py"
+tfy trigger job --application-fqn "<cluster:workspace:job>" -- --param value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required job deployment FQN.
+- `--command TEXT` - command to run.
+- `--run-name-alias TEXT` / `--run_name_alias TEXT` - alias for the job run name.
+- `--help` / `-h` - show command help.
+
+Ask before triggering jobs because it can start compute and cost.
+
+### `tfy trigger workflow`
+
+Trigger a workflow.
+
+```bash
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>"
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>" -- --input value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required workflow application FQN.
+- `--help` / `-h` - show command help.
+
+Ask before triggering workflows because it can start compute and cost.
+
+## ML Downloads
+
+### `tfy ml download artifact`
+
+Download a logged artifact version.
+
+```bash
+tfy ml download artifact --fqn "<artifact-version-fqn>" --path ./downloads
+```
+
+Options:
+- `--fqn TEXT` - required artifact version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+### `tfy ml download model`
+
+Download a logged model version.
+
+```bash
+tfy ml download model --fqn "<model-version-fqn>" --path ./models
+```
+
+Options:
+- `--fqn TEXT` - required model version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+## Destructive Or Blocked Commands
+
+These commands exist in the CLI but must not be executed by these skills. Provide manual dashboard instructions instead.
+
+### `tfy delete`
+
+Delete TrueFoundry resources.
+
+Observed forms:
+- `tfy delete -f manifest.yaml`
+- `tfy delete application --application-fqn "<application-fqn>"`
+- `tfy delete workspace --workspace-fqn "<workspace-fqn>"`
+
+Options:
+- `--file FILE` / `-f FILE` - manifest file(s) identifying resources to delete.
+- `tfy delete application`: `--application-fqn TEXT` / `--application_fqn TEXT`, `--yes`.
+- `tfy delete workspace`: `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT`, `--yes`.
+
+### `tfy terminate job`
+
+Terminate a job run.
+
+```bash
+tfy terminate job --job-fqn "<job-fqn>" --job-run-name "<run-name>"
+```
+
+Options:
+- `--job-fqn TEXT` / `--job_fqn TEXT` - required job FQN.
+- `--job-run-name TEXT` / `--job_run_name TEXT` - required run name.
+- `--help` / `-h` - show command help.
+
+## Commands That Do Not Exist In `tfy 0.13.12`
+
+The following are not valid `tfy` commands. Do not attempt them:
+
+- `tfy whoami`
+- `tfy show-config`
+- `tfy status`
+- `tfy config`, `tfy config get`, `tfy config set`
+- `tfy list`
+- `tfy describe`
+- `tfy logs`
+- `tfy exec`
+- `tfy init`
+- `tfy create`
+- `tfy ask`
+- top-level `tfy download` or `tfy upload` (`tfy ml download ...` is valid)
 
 ## Decision Tree
 
-```
-Need to CREATE/UPDATE/DELETE a resource?
-  → tfy apply / tfy delete
-
-Need to READ/LIST/QUERY a resource?
-  → REST API via tfy-api.sh or curl
-
+```text
 Need to verify login?
-  → Check ~/.truefoundry/credentials.json (see prerequisites.md)
+  -> Check ~/.truefoundry/credentials.json (see prerequisites.md)
+
+Need to read/list/query gateway or platform resources?
+  -> Use the REST API via tfy-api.sh or curl
+
+Need kubeconfig?
+  -> tfy get kubeconfig
+
+Need to create/update resources from manifests?
+  -> tfy apply with dry-run/diff first, then explicit user confirmation
+
+Need to deploy or patch live applications?
+  -> tfy deploy / tfy patch-application only after workspace confirmation and user approval
+
+Need to delete, terminate, revoke, remove, or purge anything?
+  -> Do not run CLI/API destructive commands; provide manual dashboard steps
 ```

--- a/skills/mcp-servers/references/cli-reference.md
+++ b/skills/mcp-servers/references/cli-reference.md
@@ -1,6 +1,10 @@
 # TrueFoundry CLI Reference
 
-The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for querying, listing, or inspecting resources. For read operations, use the REST API via `tfy-api.sh`.
+This reference is grounded in `tfy --help` from `tfy 0.13.12`.
+
+Do not guess `tfy` subcommands from common CLI patterns. Before using any `tfy` command not shown in this file, run `tfy --help` or `tfy <subcommand> --help` and use only commands that appear in that help output.
+
+For gateway/platform read operations, prefer the REST API via `tfy-api.sh`. The CLI has `tfy get kubeconfig`, but it does not provide general list/describe/status commands for TrueFoundry resources.
 
 ## Installation
 
@@ -8,127 +12,335 @@ The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for queryi
 pip install -U "truefoundry"
 ```
 
-Requires Python 3.9–3.14. Optional extras:
-- `pip install -U "truefoundry[workflow]"` — workflow support (Python 3.9–3.12)
-- `pip install -U "truefoundry[workflow,spark]"` — workflow + Spark
+Requires Python 3.9-3.14. Optional extras:
+- `pip install -U "truefoundry[workflow]"` - workflow support (Python 3.9-3.12)
+- `pip install -U "truefoundry[workflow,spark]"` - workflow + Spark
 
-## Commands
+## Global Options
 
-### tfy login
+| Command | Purpose |
+|---|---|
+| `tfy --version` | Print the installed CLI version. |
+| `tfy --json <command>` | Output entities in JSON format where the command supports entities. |
+| `tfy --debug <command>` | Enable debug logging. Can also be set with `TFY_DEBUG=1`. |
+| `tfy --help` / `tfy -h` | Show top-level help. |
+
+## Command Index
+
+| Command | Purpose | Skill usage guidance |
+|---|---|---|
+| `tfy apply` | Create/update resources from manifest files. | Allowed only after dry-run/diff plus explicit user confirmation. |
+| `tfy delete` | Delete resources. | Do not execute from skills; provide manual dashboard instructions instead. |
+| `tfy deploy` | Deploy an application from a `truefoundry.yaml` file. | Confirm workspace before use. |
+| `tfy deploy workflow` | Deploy a workflow file. | Confirm workspace before use. |
+| `tfy deploy-init model` | Generate model server application code for a model version. | Safe scaffolding command; still confirm output path. |
+| `tfy get kubeconfig` | Update kubeconfig for a TrueFoundry cluster. | Only CLI read-style command observed. |
+| `tfy login` | Login to a TrueFoundry tenant. | Valid onboarding command. |
+| `tfy logout` | Logout from the current session. | Do not run unless the user explicitly asks. |
+| `tfy ml download artifact` | Download a logged artifact version. | Writes files locally; confirm path/overwrite. |
+| `tfy ml download model` | Download a logged model version. | Writes files locally; confirm path/overwrite. |
+| `tfy patch` | Patch a local YAML file with a `yq` filter. | Local file mutation; review target file/output path first. |
+| `tfy patch-application` | Patch and deploy an existing application. | Deployment mutation; requires explicit user confirmation. |
+| `tfy terminate job` | Terminate a job run. | Do not execute from skills; destructive operational action. |
+| `tfy trigger job` | Trigger a job run asynchronously. | Ask before triggering; may start compute/cost. |
+| `tfy trigger workflow` | Trigger a workflow run. | Ask before triggering; may start compute/cost. |
+
+## Authentication
+
+### `tfy login`
 
 Authenticate the CLI against a TrueFoundry tenant.
 
 ```bash
-# Interactive (opens browser for device code flow) — recommended
+# Interactive login
 tfy login --host https://your-org.truefoundry.cloud
 
-# Non-interactive (CI/CD only — key appears in shell history)
+# Non-interactive login
 tfy login --host https://your-org.truefoundry.cloud --api-key "$TFY_API_KEY"
 ```
 
-Stores credentials in `~/.truefoundry/credentials.json`.
+Options:
+- `--host TEXT` - required tenant URL; can be set with `TFY_HOST`.
+- `--api-key TEXT` / `--api_key TEXT` - API key for non-interactive login.
+- `--relogin` - force relogin.
+- `--help` / `-h` - show command help.
 
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--host` | Yes | Tenant URL (e.g. `https://acme.truefoundry.cloud`) |
-| `--api-key` | No | API key for non-interactive login (CI/CD) |
+After `tfy login`, credentials are stored in:
 
-### tfy apply
-
-Create or update resources from YAML manifests.
-
-```bash
-# Single file
-tfy apply -f manifest.yaml
-
-# Multiple files
-tfy apply -f manifest1.yaml -f manifest2.yaml
-
-# Entire directory (recursive, discovers *.yaml and *.yml)
-tfy apply --dir ./manifests
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) to apply. Repeatable. |
-| `--dir <path>` | Directory of manifests (cannot combine with `-f`) |
-| `--dry-run` | Simulate changes without persisting |
-| `--show-diff` | Show diff between manifest and deployed state |
-| `--diffs-only` | Apply only changed files vs HEAD (requires `--dir`) |
-| `--ref <ref>` | Git ref to diff against (default: HEAD). Use with `--diffs-only` |
-| `--sync` | Delete platform resources for removed YAML files (requires `--dir` + `--diffs-only`) |
-
-**Supported resource types:** provider-account, gateway-load-balancing-config, gateway-rate-limiting-config, gateway-budget-config, gateway-guardrails-config, mcp-server, workspace, cluster, application, secret-group, ml-repo, agent, agent-skill
-
-**Environment:** Requires `TFY_HOST` to be set when `TFY_API_KEY` is in the environment:
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
-```
-
-### tfy delete
-
-Delete resources using the same manifest files used with `tfy apply`.
-
-```bash
-# Single file
-tfy delete -f manifest.yaml
-
-# Multiple files
-tfy delete -f manifest1.yaml -f manifest2.yaml
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) identifying resources to delete. Repeatable. |
-
-### tfy --version
-
-Print the installed CLI version.
-
-```bash
-tfy --version
-# Output: tfy version X.Y.Z
-```
-
-## Commands That DO NOT Exist
-
-The following are **not valid** `tfy` subcommands. Do not attempt them:
-
-- `tfy get` / `tfy list` / `tfy describe`
-- `tfy config` / `tfy config get` / `tfy config set`
-- `tfy whoami` / `tfy status`
-- `tfy download` / `tfy upload`
-- `tfy init` / `tfy create`
-- `tfy logs` / `tfy exec`
-
-For all read/query operations, use the REST API directly via `tfy-api.sh` or `curl`.
-
-## Authentication Modes
-
-| Mode | How | When |
-|------|-----|------|
-| Interactive login | `tfy login --host <url>` | Local development |
-| Environment variables | `TFY_HOST` + `TFY_API_KEY` | CI/CD, scripts, `tfy-api.sh` |
-| Non-interactive login | `tfy login --host <url> --api-key <key>` | CI/CD (key in history — prefer env vars) |
-
-## Credential Storage
-
-After `tfy login`, credentials are stored at:
-```
+```text
 ~/.truefoundry/credentials.json
 ```
 
-Fields: `host`, `access_token`, `refresh_token`.
+Fields include `host`, `access_token`, and `refresh_token`.
+
+### `tfy logout`
+
+Logout from the current TrueFoundry session.
+
+```bash
+tfy logout
+```
+
+Do not run this unless the user explicitly asks to logout.
+
+## Apply And Deploy
+
+### `tfy apply`
+
+Create or update resources from manifest files.
+
+```bash
+tfy apply -f manifest.yaml
+tfy apply -f manifest1.yaml -f manifest2.yaml
+tfy apply -f manifest.yaml --dry-run --show-diff
+```
+
+Options:
+- `--file FILE` / `-f FILE` - required manifest file. Repeat for multiple files.
+- `--dry-run` / `--dry_run` - simulate without applying.
+- `--show-diff` / `--show_diff` - print manifest differences when using `--dry-run`.
+- `--help` / `-h` - show command help.
+
+Before the final non-dry-run apply, show the target host/workspace, an English summary, the YAML or diff, the exact command, and wait for explicit user confirmation.
+
+### `tfy deploy`
+
+Deploy an application to TrueFoundry.
+
+```bash
+tfy deploy -f truefoundry.yaml -w "<workspace-fqn>"
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to `truefoundry.yaml`.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - workspace FQN. If omitted, the CLI reads it from the deployment spec when available.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--force` / `--no-force` - cancel ongoing deployments and force a new one. Defaults to no-force.
+- `--trigger-on-deploy` / `--trigger_on_deploy` / `--no-trigger-on-deploy` / `--no_trigger_on_deploy` - trigger a job run after deployment succeeds. No effect for non-job deployments.
+- `--help` / `-h` - show command help.
+
+Always confirm the workspace before deployment. Treat `--force` and trigger-on-deploy as higher-risk options requiring explicit user confirmation.
+
+### `tfy deploy workflow`
+
+Deploy a workflow file.
+
+```bash
+tfy deploy workflow --name "<workflow-name>" -f workflow.py -w "<workspace-fqn>"
+```
+
+Options:
+- `--name TEXT` / `-n TEXT` - required workflow name.
+- `--file FILE` / `-f FILE` - required workflow file.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - required workspace FQN.
+- `--help` / `-h` - show command help.
+
+### `tfy deploy-init model`
+
+Generate application code for a model server deployment.
+
+```bash
+tfy deploy-init model \
+  --name "<application-name>" \
+  --model-version-fqn "<model-version-fqn>" \
+  --workspace-fqn "<workspace-fqn>" \
+  --model-server fastapi \
+  --output-dir ./model-server
+```
+
+Options:
+- `--name APPLICATION-NAME` - required model server deployment name.
+- `--model-version-fqn NON-EMPTY-STRING` / `--model_version_fqn` - required model version FQN.
+- `--workspace-fqn NON-EMPTY-STRING` / `--workspace_fqn` / `-w` - required workspace FQN.
+- `--model-server [triton|fastapi]` / `--model_server` - model server type. Defaults to `fastapi`.
+- `--output-dir DIRECTORY` / `--output_dir` - output directory for generated code.
+- `--help` / `-h` - show command help.
+
+## Local Patching
+
+### `tfy patch`
+
+Patch a local YAML file with a `yq` filter.
+
+```bash
+tfy patch -f servicefoundry.yaml --filter '.image.image_uri = "repo/image:tag"' -o patched.yaml
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to servicefoundry YAML. Defaults to `./servicefoundry.yaml`.
+- `--filter TEXT` - required `yq` filter.
+- `--output-file PATH` / `-o PATH` - write output to a file.
+- `--indent INTEGER` / `-I INTEGER` - output indent. Defaults to `4`.
+- `--help` / `-h` - show command help.
+
+### `tfy patch-application`
+
+Patch and deploy an existing application.
+
+```bash
+tfy patch-application --application-fqn "<application-fqn>" --patch-file patch.yaml
+tfy patch-application --application-fqn "<application-fqn>" --patch '{"key":"value"}'
+```
+
+Options:
+- `--patch-file FILE` / `--patch_file FILE` / `-f FILE` - YAML patch file.
+- `--patch TEXT` / `-p TEXT` - JSON patch string.
+- `--application-fqn TEXT` / `--application_fqn TEXT` / `-a TEXT` - required application FQN.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--help` / `-h` - show command help.
+
+This mutates a live application. Show the patch and wait for explicit user confirmation before running.
+
+## Read-Style Commands
+
+### `tfy get kubeconfig`
+
+Update kubeconfig to access a cluster attached to the TrueFoundry Control Plane.
+
+```bash
+tfy get kubeconfig --cluster "<cluster-id>" --overwrite
+```
+
+Options:
+- `--cluster TEXT` / `-c TEXT` - cluster ID. If omitted, the CLI opens an interactive cluster picker.
+- `--overwrite` - overwrite an existing cluster entry without prompting.
+- `--help` / `-h` - show command help.
+
+This writes to `~/.kube/config` by default, or to the first path in `KUBECONFIG`.
+
+## Triggering Work
+
+### `tfy trigger job`
+
+Trigger a job asynchronously.
+
+```bash
+tfy trigger job --application-fqn "<cluster:workspace:job>"
+tfy trigger job --application-fqn "<cluster:workspace:job>" --command "python run.py"
+tfy trigger job --application-fqn "<cluster:workspace:job>" -- --param value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required job deployment FQN.
+- `--command TEXT` - command to run.
+- `--run-name-alias TEXT` / `--run_name_alias TEXT` - alias for the job run name.
+- `--help` / `-h` - show command help.
+
+Ask before triggering jobs because it can start compute and cost.
+
+### `tfy trigger workflow`
+
+Trigger a workflow.
+
+```bash
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>"
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>" -- --input value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required workflow application FQN.
+- `--help` / `-h` - show command help.
+
+Ask before triggering workflows because it can start compute and cost.
+
+## ML Downloads
+
+### `tfy ml download artifact`
+
+Download a logged artifact version.
+
+```bash
+tfy ml download artifact --fqn "<artifact-version-fqn>" --path ./downloads
+```
+
+Options:
+- `--fqn TEXT` - required artifact version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+### `tfy ml download model`
+
+Download a logged model version.
+
+```bash
+tfy ml download model --fqn "<model-version-fqn>" --path ./models
+```
+
+Options:
+- `--fqn TEXT` - required model version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+## Destructive Or Blocked Commands
+
+These commands exist in the CLI but must not be executed by these skills. Provide manual dashboard instructions instead.
+
+### `tfy delete`
+
+Delete TrueFoundry resources.
+
+Observed forms:
+- `tfy delete -f manifest.yaml`
+- `tfy delete application --application-fqn "<application-fqn>"`
+- `tfy delete workspace --workspace-fqn "<workspace-fqn>"`
+
+Options:
+- `--file FILE` / `-f FILE` - manifest file(s) identifying resources to delete.
+- `tfy delete application`: `--application-fqn TEXT` / `--application_fqn TEXT`, `--yes`.
+- `tfy delete workspace`: `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT`, `--yes`.
+
+### `tfy terminate job`
+
+Terminate a job run.
+
+```bash
+tfy terminate job --job-fqn "<job-fqn>" --job-run-name "<run-name>"
+```
+
+Options:
+- `--job-fqn TEXT` / `--job_fqn TEXT` - required job FQN.
+- `--job-run-name TEXT` / `--job_run_name TEXT` - required run name.
+- `--help` / `-h` - show command help.
+
+## Commands That Do Not Exist In `tfy 0.13.12`
+
+The following are not valid `tfy` commands. Do not attempt them:
+
+- `tfy whoami`
+- `tfy show-config`
+- `tfy status`
+- `tfy config`, `tfy config get`, `tfy config set`
+- `tfy list`
+- `tfy describe`
+- `tfy logs`
+- `tfy exec`
+- `tfy init`
+- `tfy create`
+- `tfy ask`
+- top-level `tfy download` or `tfy upload` (`tfy ml download ...` is valid)
 
 ## Decision Tree
 
-```
-Need to CREATE/UPDATE/DELETE a resource?
-  → tfy apply / tfy delete
-
-Need to READ/LIST/QUERY a resource?
-  → REST API via tfy-api.sh or curl
-
+```text
 Need to verify login?
-  → Check ~/.truefoundry/credentials.json (see prerequisites.md)
+  -> Check ~/.truefoundry/credentials.json (see prerequisites.md)
+
+Need to read/list/query gateway or platform resources?
+  -> Use the REST API via tfy-api.sh or curl
+
+Need kubeconfig?
+  -> tfy get kubeconfig
+
+Need to create/update resources from manifests?
+  -> tfy apply with dry-run/diff first, then explicit user confirmation
+
+Need to deploy or patch live applications?
+  -> tfy deploy / tfy patch-application only after workspace confirmation and user approval
+
+Need to delete, terminate, revoke, remove, or purge anything?
+  -> Do not run CLI/API destructive commands; provide manual dashboard steps
 ```

--- a/skills/mcp-servers/references/prerequisites.md
+++ b/skills/mcp-servers/references/prerequisites.md
@@ -2,16 +2,10 @@
 
 ## Step 0: CLI and Login Check
 
-Check if the TrueFoundry CLI is available:
+First check if the TrueFoundry CLI is available. This tells you whether the TrueFoundry Python package and `tfy` entrypoint are installed:
 
 ```bash
 tfy --version 2>/dev/null
-```
-
-If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
-
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
 ```
 
 If not found, install it:
@@ -20,9 +14,7 @@ If not found, install it:
 pip install 'truefoundry==0.5.0'
 ```
 
-> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
-
-Before any non-onboarding skill changes TrueFoundry resources, check that CLI login already exists:
+After `tfy --version` works, check whether CLI login already exists:
 
 ```bash
 python3 - <<'PY'
@@ -44,17 +36,38 @@ else:
 PY
 ```
 
+If login is missing, say:
+
+```text
+Looks like the tenant is not set or CLI login is not done.
+If you have not already, create an account at https://www.truefoundry.com/register, complete the onboarding/signup flow, and paste your tenant URL here.
+```
+
+Then use the onboard skill to run:
+
+```bash
+tfy login --host "<tenant-url>"
+```
+
+If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
+
+```bash
+export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
+```
+
+> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
+
 If the user does not have a TrueFoundry tenant or CLI login yet, stop and use the `truefoundry-onboard` skill. Do not duplicate onboarding steps in other skills.
 
 ## CLI Command Boundaries
 
-The `tfy` CLI only supports these subcommands:
+The current CLI surface is documented in `cli-reference.md`. Do not guess commands from common CLI patterns. If a command is not in `cli-reference.md`, run `tfy --help` or `tfy <subcommand> --help` before using it.
 
-- `tfy login` — authenticate
-- `tfy apply` — apply manifests
-- `tfy --version` — version check
+Common valid commands include `tfy login`, `tfy apply`, `tfy deploy`, `tfy get kubeconfig`, `tfy trigger job`, `tfy trigger workflow`, and `tfy ml download ...`.
 
-**These do NOT exist:** `tfy get`, `tfy config`, `tfy whoami`, `tfy list`, `tfy status`, `tfy download`, `tfy upload`. Do not probe for them. For any read operation, use the REST API via `tfy-api.sh`.
+Destructive commands such as `tfy delete` and `tfy terminate job` exist, but these skills must not execute them. Provide manual dashboard instructions instead.
+
+**These do NOT exist:** `tfy config`, `tfy show-config`, `tfy whoami`, `tfy list`, `tfy status`, top-level `tfy download`, and top-level `tfy upload`. Do not probe for them. For gateway/platform read operations, use the REST API via `tfy-api.sh`.
 
 ## Credential Check
 

--- a/skills/observability/references/cli-reference.md
+++ b/skills/observability/references/cli-reference.md
@@ -1,6 +1,10 @@
 # TrueFoundry CLI Reference
 
-The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for querying, listing, or inspecting resources. For read operations, use the REST API via `tfy-api.sh`.
+This reference is grounded in `tfy --help` from `tfy 0.13.12`.
+
+Do not guess `tfy` subcommands from common CLI patterns. Before using any `tfy` command not shown in this file, run `tfy --help` or `tfy <subcommand> --help` and use only commands that appear in that help output.
+
+For gateway/platform read operations, prefer the REST API via `tfy-api.sh`. The CLI has `tfy get kubeconfig`, but it does not provide general list/describe/status commands for TrueFoundry resources.
 
 ## Installation
 
@@ -8,127 +12,335 @@ The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for queryi
 pip install -U "truefoundry"
 ```
 
-Requires Python 3.9–3.14. Optional extras:
-- `pip install -U "truefoundry[workflow]"` — workflow support (Python 3.9–3.12)
-- `pip install -U "truefoundry[workflow,spark]"` — workflow + Spark
+Requires Python 3.9-3.14. Optional extras:
+- `pip install -U "truefoundry[workflow]"` - workflow support (Python 3.9-3.12)
+- `pip install -U "truefoundry[workflow,spark]"` - workflow + Spark
 
-## Commands
+## Global Options
 
-### tfy login
+| Command | Purpose |
+|---|---|
+| `tfy --version` | Print the installed CLI version. |
+| `tfy --json <command>` | Output entities in JSON format where the command supports entities. |
+| `tfy --debug <command>` | Enable debug logging. Can also be set with `TFY_DEBUG=1`. |
+| `tfy --help` / `tfy -h` | Show top-level help. |
+
+## Command Index
+
+| Command | Purpose | Skill usage guidance |
+|---|---|---|
+| `tfy apply` | Create/update resources from manifest files. | Allowed only after dry-run/diff plus explicit user confirmation. |
+| `tfy delete` | Delete resources. | Do not execute from skills; provide manual dashboard instructions instead. |
+| `tfy deploy` | Deploy an application from a `truefoundry.yaml` file. | Confirm workspace before use. |
+| `tfy deploy workflow` | Deploy a workflow file. | Confirm workspace before use. |
+| `tfy deploy-init model` | Generate model server application code for a model version. | Safe scaffolding command; still confirm output path. |
+| `tfy get kubeconfig` | Update kubeconfig for a TrueFoundry cluster. | Only CLI read-style command observed. |
+| `tfy login` | Login to a TrueFoundry tenant. | Valid onboarding command. |
+| `tfy logout` | Logout from the current session. | Do not run unless the user explicitly asks. |
+| `tfy ml download artifact` | Download a logged artifact version. | Writes files locally; confirm path/overwrite. |
+| `tfy ml download model` | Download a logged model version. | Writes files locally; confirm path/overwrite. |
+| `tfy patch` | Patch a local YAML file with a `yq` filter. | Local file mutation; review target file/output path first. |
+| `tfy patch-application` | Patch and deploy an existing application. | Deployment mutation; requires explicit user confirmation. |
+| `tfy terminate job` | Terminate a job run. | Do not execute from skills; destructive operational action. |
+| `tfy trigger job` | Trigger a job run asynchronously. | Ask before triggering; may start compute/cost. |
+| `tfy trigger workflow` | Trigger a workflow run. | Ask before triggering; may start compute/cost. |
+
+## Authentication
+
+### `tfy login`
 
 Authenticate the CLI against a TrueFoundry tenant.
 
 ```bash
-# Interactive (opens browser for device code flow) — recommended
+# Interactive login
 tfy login --host https://your-org.truefoundry.cloud
 
-# Non-interactive (CI/CD only — key appears in shell history)
+# Non-interactive login
 tfy login --host https://your-org.truefoundry.cloud --api-key "$TFY_API_KEY"
 ```
 
-Stores credentials in `~/.truefoundry/credentials.json`.
+Options:
+- `--host TEXT` - required tenant URL; can be set with `TFY_HOST`.
+- `--api-key TEXT` / `--api_key TEXT` - API key for non-interactive login.
+- `--relogin` - force relogin.
+- `--help` / `-h` - show command help.
 
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--host` | Yes | Tenant URL (e.g. `https://acme.truefoundry.cloud`) |
-| `--api-key` | No | API key for non-interactive login (CI/CD) |
+After `tfy login`, credentials are stored in:
 
-### tfy apply
-
-Create or update resources from YAML manifests.
-
-```bash
-# Single file
-tfy apply -f manifest.yaml
-
-# Multiple files
-tfy apply -f manifest1.yaml -f manifest2.yaml
-
-# Entire directory (recursive, discovers *.yaml and *.yml)
-tfy apply --dir ./manifests
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) to apply. Repeatable. |
-| `--dir <path>` | Directory of manifests (cannot combine with `-f`) |
-| `--dry-run` | Simulate changes without persisting |
-| `--show-diff` | Show diff between manifest and deployed state |
-| `--diffs-only` | Apply only changed files vs HEAD (requires `--dir`) |
-| `--ref <ref>` | Git ref to diff against (default: HEAD). Use with `--diffs-only` |
-| `--sync` | Delete platform resources for removed YAML files (requires `--dir` + `--diffs-only`) |
-
-**Supported resource types:** provider-account, gateway-load-balancing-config, gateway-rate-limiting-config, gateway-budget-config, gateway-guardrails-config, mcp-server, workspace, cluster, application, secret-group, ml-repo, agent, agent-skill
-
-**Environment:** Requires `TFY_HOST` to be set when `TFY_API_KEY` is in the environment:
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
-```
-
-### tfy delete
-
-Delete resources using the same manifest files used with `tfy apply`.
-
-```bash
-# Single file
-tfy delete -f manifest.yaml
-
-# Multiple files
-tfy delete -f manifest1.yaml -f manifest2.yaml
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) identifying resources to delete. Repeatable. |
-
-### tfy --version
-
-Print the installed CLI version.
-
-```bash
-tfy --version
-# Output: tfy version X.Y.Z
-```
-
-## Commands That DO NOT Exist
-
-The following are **not valid** `tfy` subcommands. Do not attempt them:
-
-- `tfy get` / `tfy list` / `tfy describe`
-- `tfy config` / `tfy config get` / `tfy config set`
-- `tfy whoami` / `tfy status`
-- `tfy download` / `tfy upload`
-- `tfy init` / `tfy create`
-- `tfy logs` / `tfy exec`
-
-For all read/query operations, use the REST API directly via `tfy-api.sh` or `curl`.
-
-## Authentication Modes
-
-| Mode | How | When |
-|------|-----|------|
-| Interactive login | `tfy login --host <url>` | Local development |
-| Environment variables | `TFY_HOST` + `TFY_API_KEY` | CI/CD, scripts, `tfy-api.sh` |
-| Non-interactive login | `tfy login --host <url> --api-key <key>` | CI/CD (key in history — prefer env vars) |
-
-## Credential Storage
-
-After `tfy login`, credentials are stored at:
-```
+```text
 ~/.truefoundry/credentials.json
 ```
 
-Fields: `host`, `access_token`, `refresh_token`.
+Fields include `host`, `access_token`, and `refresh_token`.
+
+### `tfy logout`
+
+Logout from the current TrueFoundry session.
+
+```bash
+tfy logout
+```
+
+Do not run this unless the user explicitly asks to logout.
+
+## Apply And Deploy
+
+### `tfy apply`
+
+Create or update resources from manifest files.
+
+```bash
+tfy apply -f manifest.yaml
+tfy apply -f manifest1.yaml -f manifest2.yaml
+tfy apply -f manifest.yaml --dry-run --show-diff
+```
+
+Options:
+- `--file FILE` / `-f FILE` - required manifest file. Repeat for multiple files.
+- `--dry-run` / `--dry_run` - simulate without applying.
+- `--show-diff` / `--show_diff` - print manifest differences when using `--dry-run`.
+- `--help` / `-h` - show command help.
+
+Before the final non-dry-run apply, show the target host/workspace, an English summary, the YAML or diff, the exact command, and wait for explicit user confirmation.
+
+### `tfy deploy`
+
+Deploy an application to TrueFoundry.
+
+```bash
+tfy deploy -f truefoundry.yaml -w "<workspace-fqn>"
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to `truefoundry.yaml`.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - workspace FQN. If omitted, the CLI reads it from the deployment spec when available.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--force` / `--no-force` - cancel ongoing deployments and force a new one. Defaults to no-force.
+- `--trigger-on-deploy` / `--trigger_on_deploy` / `--no-trigger-on-deploy` / `--no_trigger_on_deploy` - trigger a job run after deployment succeeds. No effect for non-job deployments.
+- `--help` / `-h` - show command help.
+
+Always confirm the workspace before deployment. Treat `--force` and trigger-on-deploy as higher-risk options requiring explicit user confirmation.
+
+### `tfy deploy workflow`
+
+Deploy a workflow file.
+
+```bash
+tfy deploy workflow --name "<workflow-name>" -f workflow.py -w "<workspace-fqn>"
+```
+
+Options:
+- `--name TEXT` / `-n TEXT` - required workflow name.
+- `--file FILE` / `-f FILE` - required workflow file.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - required workspace FQN.
+- `--help` / `-h` - show command help.
+
+### `tfy deploy-init model`
+
+Generate application code for a model server deployment.
+
+```bash
+tfy deploy-init model \
+  --name "<application-name>" \
+  --model-version-fqn "<model-version-fqn>" \
+  --workspace-fqn "<workspace-fqn>" \
+  --model-server fastapi \
+  --output-dir ./model-server
+```
+
+Options:
+- `--name APPLICATION-NAME` - required model server deployment name.
+- `--model-version-fqn NON-EMPTY-STRING` / `--model_version_fqn` - required model version FQN.
+- `--workspace-fqn NON-EMPTY-STRING` / `--workspace_fqn` / `-w` - required workspace FQN.
+- `--model-server [triton|fastapi]` / `--model_server` - model server type. Defaults to `fastapi`.
+- `--output-dir DIRECTORY` / `--output_dir` - output directory for generated code.
+- `--help` / `-h` - show command help.
+
+## Local Patching
+
+### `tfy patch`
+
+Patch a local YAML file with a `yq` filter.
+
+```bash
+tfy patch -f servicefoundry.yaml --filter '.image.image_uri = "repo/image:tag"' -o patched.yaml
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to servicefoundry YAML. Defaults to `./servicefoundry.yaml`.
+- `--filter TEXT` - required `yq` filter.
+- `--output-file PATH` / `-o PATH` - write output to a file.
+- `--indent INTEGER` / `-I INTEGER` - output indent. Defaults to `4`.
+- `--help` / `-h` - show command help.
+
+### `tfy patch-application`
+
+Patch and deploy an existing application.
+
+```bash
+tfy patch-application --application-fqn "<application-fqn>" --patch-file patch.yaml
+tfy patch-application --application-fqn "<application-fqn>" --patch '{"key":"value"}'
+```
+
+Options:
+- `--patch-file FILE` / `--patch_file FILE` / `-f FILE` - YAML patch file.
+- `--patch TEXT` / `-p TEXT` - JSON patch string.
+- `--application-fqn TEXT` / `--application_fqn TEXT` / `-a TEXT` - required application FQN.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--help` / `-h` - show command help.
+
+This mutates a live application. Show the patch and wait for explicit user confirmation before running.
+
+## Read-Style Commands
+
+### `tfy get kubeconfig`
+
+Update kubeconfig to access a cluster attached to the TrueFoundry Control Plane.
+
+```bash
+tfy get kubeconfig --cluster "<cluster-id>" --overwrite
+```
+
+Options:
+- `--cluster TEXT` / `-c TEXT` - cluster ID. If omitted, the CLI opens an interactive cluster picker.
+- `--overwrite` - overwrite an existing cluster entry without prompting.
+- `--help` / `-h` - show command help.
+
+This writes to `~/.kube/config` by default, or to the first path in `KUBECONFIG`.
+
+## Triggering Work
+
+### `tfy trigger job`
+
+Trigger a job asynchronously.
+
+```bash
+tfy trigger job --application-fqn "<cluster:workspace:job>"
+tfy trigger job --application-fqn "<cluster:workspace:job>" --command "python run.py"
+tfy trigger job --application-fqn "<cluster:workspace:job>" -- --param value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required job deployment FQN.
+- `--command TEXT` - command to run.
+- `--run-name-alias TEXT` / `--run_name_alias TEXT` - alias for the job run name.
+- `--help` / `-h` - show command help.
+
+Ask before triggering jobs because it can start compute and cost.
+
+### `tfy trigger workflow`
+
+Trigger a workflow.
+
+```bash
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>"
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>" -- --input value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required workflow application FQN.
+- `--help` / `-h` - show command help.
+
+Ask before triggering workflows because it can start compute and cost.
+
+## ML Downloads
+
+### `tfy ml download artifact`
+
+Download a logged artifact version.
+
+```bash
+tfy ml download artifact --fqn "<artifact-version-fqn>" --path ./downloads
+```
+
+Options:
+- `--fqn TEXT` - required artifact version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+### `tfy ml download model`
+
+Download a logged model version.
+
+```bash
+tfy ml download model --fqn "<model-version-fqn>" --path ./models
+```
+
+Options:
+- `--fqn TEXT` - required model version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+## Destructive Or Blocked Commands
+
+These commands exist in the CLI but must not be executed by these skills. Provide manual dashboard instructions instead.
+
+### `tfy delete`
+
+Delete TrueFoundry resources.
+
+Observed forms:
+- `tfy delete -f manifest.yaml`
+- `tfy delete application --application-fqn "<application-fqn>"`
+- `tfy delete workspace --workspace-fqn "<workspace-fqn>"`
+
+Options:
+- `--file FILE` / `-f FILE` - manifest file(s) identifying resources to delete.
+- `tfy delete application`: `--application-fqn TEXT` / `--application_fqn TEXT`, `--yes`.
+- `tfy delete workspace`: `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT`, `--yes`.
+
+### `tfy terminate job`
+
+Terminate a job run.
+
+```bash
+tfy terminate job --job-fqn "<job-fqn>" --job-run-name "<run-name>"
+```
+
+Options:
+- `--job-fqn TEXT` / `--job_fqn TEXT` - required job FQN.
+- `--job-run-name TEXT` / `--job_run_name TEXT` - required run name.
+- `--help` / `-h` - show command help.
+
+## Commands That Do Not Exist In `tfy 0.13.12`
+
+The following are not valid `tfy` commands. Do not attempt them:
+
+- `tfy whoami`
+- `tfy show-config`
+- `tfy status`
+- `tfy config`, `tfy config get`, `tfy config set`
+- `tfy list`
+- `tfy describe`
+- `tfy logs`
+- `tfy exec`
+- `tfy init`
+- `tfy create`
+- `tfy ask`
+- top-level `tfy download` or `tfy upload` (`tfy ml download ...` is valid)
 
 ## Decision Tree
 
-```
-Need to CREATE/UPDATE/DELETE a resource?
-  → tfy apply / tfy delete
-
-Need to READ/LIST/QUERY a resource?
-  → REST API via tfy-api.sh or curl
-
+```text
 Need to verify login?
-  → Check ~/.truefoundry/credentials.json (see prerequisites.md)
+  -> Check ~/.truefoundry/credentials.json (see prerequisites.md)
+
+Need to read/list/query gateway or platform resources?
+  -> Use the REST API via tfy-api.sh or curl
+
+Need kubeconfig?
+  -> tfy get kubeconfig
+
+Need to create/update resources from manifests?
+  -> tfy apply with dry-run/diff first, then explicit user confirmation
+
+Need to deploy or patch live applications?
+  -> tfy deploy / tfy patch-application only after workspace confirmation and user approval
+
+Need to delete, terminate, revoke, remove, or purge anything?
+  -> Do not run CLI/API destructive commands; provide manual dashboard steps
 ```

--- a/skills/observability/references/prerequisites.md
+++ b/skills/observability/references/prerequisites.md
@@ -2,16 +2,10 @@
 
 ## Step 0: CLI and Login Check
 
-Check if the TrueFoundry CLI is available:
+First check if the TrueFoundry CLI is available. This tells you whether the TrueFoundry Python package and `tfy` entrypoint are installed:
 
 ```bash
 tfy --version 2>/dev/null
-```
-
-If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
-
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
 ```
 
 If not found, install it:
@@ -20,9 +14,7 @@ If not found, install it:
 pip install 'truefoundry==0.5.0'
 ```
 
-> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
-
-Before any non-onboarding skill changes TrueFoundry resources, check that CLI login already exists:
+After `tfy --version` works, check whether CLI login already exists:
 
 ```bash
 python3 - <<'PY'
@@ -44,17 +36,38 @@ else:
 PY
 ```
 
+If login is missing, say:
+
+```text
+Looks like the tenant is not set or CLI login is not done.
+If you have not already, create an account at https://www.truefoundry.com/register, complete the onboarding/signup flow, and paste your tenant URL here.
+```
+
+Then use the onboard skill to run:
+
+```bash
+tfy login --host "<tenant-url>"
+```
+
+If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
+
+```bash
+export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
+```
+
+> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
+
 If the user does not have a TrueFoundry tenant or CLI login yet, stop and use the `truefoundry-onboard` skill. Do not duplicate onboarding steps in other skills.
 
 ## CLI Command Boundaries
 
-The `tfy` CLI only supports these subcommands:
+The current CLI surface is documented in `cli-reference.md`. Do not guess commands from common CLI patterns. If a command is not in `cli-reference.md`, run `tfy --help` or `tfy <subcommand> --help` before using it.
 
-- `tfy login` — authenticate
-- `tfy apply` — apply manifests
-- `tfy --version` — version check
+Common valid commands include `tfy login`, `tfy apply`, `tfy deploy`, `tfy get kubeconfig`, `tfy trigger job`, `tfy trigger workflow`, and `tfy ml download ...`.
 
-**These do NOT exist:** `tfy get`, `tfy config`, `tfy whoami`, `tfy list`, `tfy status`, `tfy download`, `tfy upload`. Do not probe for them. For any read operation, use the REST API via `tfy-api.sh`.
+Destructive commands such as `tfy delete` and `tfy terminate job` exist, but these skills must not execute them. Provide manual dashboard instructions instead.
+
+**These do NOT exist:** `tfy config`, `tfy show-config`, `tfy whoami`, `tfy list`, `tfy status`, top-level `tfy download`, and top-level `tfy upload`. Do not probe for them. For gateway/platform read operations, use the REST API via `tfy-api.sh`.
 
 ## Credential Check
 

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -25,9 +25,39 @@ Stop after CLI login verification. Operational setup belongs to the other TrueFo
 
 ## Flow
 
-### Step 1: Check Existing Login
+### Step 1: Check CLI Installation
+
+The first check is the CLI version. This tells you whether the TrueFoundry Python package and `tfy` entrypoint are installed.
 
 Run:
+
+```bash
+tfy --version 2>/dev/null
+```
+
+If this fails, install the CLI:
+
+```bash
+pip install 'truefoundry==0.5.0'
+```
+
+If `pip` is unavailable and `uv` exists, use:
+
+```bash
+uv tool install --python 3.12 'truefoundry==0.5.0'
+```
+
+Then rerun:
+
+```bash
+tfy --version
+```
+
+Do not guess common status/config commands. `tfy whoami`, `tfy show-config`, `tfy status`, and `tfy config ...` are invalid for this CLI.
+
+### Step 2: Check Existing Login
+
+After `tfy --version` works, check whether CLI login is already present:
 
 ```bash
 python3 - <<'PY'
@@ -51,11 +81,14 @@ PY
 
 If login is already present, tell the user the tenant host and stop. The next requested TrueFoundry skill can continue.
 
-### Step 2: Get Tenant URL
+### Step 3: Get Tenant URL If Login Is Missing
 
-Ask:
+If the login check prints `tfy login: missing`, say:
 
-> Do you already have a TrueFoundry tenant URL? If not, open https://www.truefoundry.com/register, create your tenant, then paste the tenant URL here.
+```text
+Looks like the tenant is not set or CLI login is not done.
+If you have not already, create an account at https://www.truefoundry.com/register, complete the onboarding/signup flow, and paste your tenant URL here.
+```
 
 Accept a full tenant URL, for example:
 
@@ -65,39 +98,25 @@ https://acme.truefoundry.cloud
 
 Use browser registration only for new tenants.
 
-### Step 3: Install or Check CLI
-
-Run:
-
-```bash
-tfy --version 2>/dev/null || pip install 'truefoundry==0.5.0'
-```
-
-If `pip` is unavailable and `uv` exists, use:
-
-```bash
-uv tool install --python 3.12 'truefoundry==0.5.0'
-```
-
 ### Step 4: Login
 
-Ask the user to complete interactive login:
+After the user provides the tenant URL, ask them to complete interactive login:
 
 ```bash
 tfy login --host "<tenant-url>"
 ```
 
-The command may open a browser. Wait for the user to confirm it succeeded.
+The command may open a browser. Wait for the user to confirm it succeeded. This sets the CLI host and stores CLI credentials on the machine.
 
 ### Step 5: Verify
 
-Run the login check from Step 1 again.
+Run the login check from Step 2 again.
 
 If it prints `tfy login: ok (...)`, onboarding is complete. Report:
 
 ```text
 TrueFoundry CLI login is complete for <tenant-url>.
-You can now use the other TrueFoundry skills.
+You can now use the other TrueFoundry skills. CLI-based flows should work from here.
 ```
 
 If it still prints missing, ask the user to rerun `tfy login --host <tenant-url>` and paste any error message.
@@ -105,9 +124,10 @@ If it still prints missing, ask the user to rerun `tfy login --host <tenant-url>
 ### After Onboarding — What NOT to Do
 
 Once `tfy login` succeeds:
-- Do NOT probe for verification commands (`tfy whoami`, `tfy config get`, `tfy get workspace`) — they don't exist.
+- Do NOT probe for verification commands (`tfy whoami`, `tfy show-config`, `tfy config get`, `tfy get workspace`, `tfy status`) — they don't exist.
 - Do NOT re-verify by fetching READMEs or documentation.
 - The single valid verification is the credentials.json check above. If that passes, login is done.
+- Direct REST helper calls via `tfy-api.sh` may still require `TFY_API_KEY`; do not claim that a separate API key exists unless it is actually set.
 - If the user immediately asks a follow-up like "what models are attached?", the answer is one API call: `$TFY_API_SH GET /api/svc/v1/provider-accounts`. Go straight there.
 
 </instructions>

--- a/skills/onboard/install.md
+++ b/skills/onboard/install.md
@@ -14,7 +14,7 @@ npx skills add truefoundry/skills --all
 
 After install, tell your agent:
 
-> Read https://www.github.com/truefoundry/skills/install.md and follow the instructions to register with TrueFoundry.
+> Read https://raw.githubusercontent.com/truefoundry/skills/main/install.md and follow the instructions to register with TrueFoundry.
 
 The onboarding flow is only:
 

--- a/skills/platform/references/cli-reference.md
+++ b/skills/platform/references/cli-reference.md
@@ -1,6 +1,10 @@
 # TrueFoundry CLI Reference
 
-The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for querying, listing, or inspecting resources. For read operations, use the REST API via `tfy-api.sh`.
+This reference is grounded in `tfy --help` from `tfy 0.13.12`.
+
+Do not guess `tfy` subcommands from common CLI patterns. Before using any `tfy` command not shown in this file, run `tfy --help` or `tfy <subcommand> --help` and use only commands that appear in that help output.
+
+For gateway/platform read operations, prefer the REST API via `tfy-api.sh`. The CLI has `tfy get kubeconfig`, but it does not provide general list/describe/status commands for TrueFoundry resources.
 
 ## Installation
 
@@ -8,127 +12,335 @@ The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for queryi
 pip install -U "truefoundry"
 ```
 
-Requires Python 3.9–3.14. Optional extras:
-- `pip install -U "truefoundry[workflow]"` — workflow support (Python 3.9–3.12)
-- `pip install -U "truefoundry[workflow,spark]"` — workflow + Spark
+Requires Python 3.9-3.14. Optional extras:
+- `pip install -U "truefoundry[workflow]"` - workflow support (Python 3.9-3.12)
+- `pip install -U "truefoundry[workflow,spark]"` - workflow + Spark
 
-## Commands
+## Global Options
 
-### tfy login
+| Command | Purpose |
+|---|---|
+| `tfy --version` | Print the installed CLI version. |
+| `tfy --json <command>` | Output entities in JSON format where the command supports entities. |
+| `tfy --debug <command>` | Enable debug logging. Can also be set with `TFY_DEBUG=1`. |
+| `tfy --help` / `tfy -h` | Show top-level help. |
+
+## Command Index
+
+| Command | Purpose | Skill usage guidance |
+|---|---|---|
+| `tfy apply` | Create/update resources from manifest files. | Allowed only after dry-run/diff plus explicit user confirmation. |
+| `tfy delete` | Delete resources. | Do not execute from skills; provide manual dashboard instructions instead. |
+| `tfy deploy` | Deploy an application from a `truefoundry.yaml` file. | Confirm workspace before use. |
+| `tfy deploy workflow` | Deploy a workflow file. | Confirm workspace before use. |
+| `tfy deploy-init model` | Generate model server application code for a model version. | Safe scaffolding command; still confirm output path. |
+| `tfy get kubeconfig` | Update kubeconfig for a TrueFoundry cluster. | Only CLI read-style command observed. |
+| `tfy login` | Login to a TrueFoundry tenant. | Valid onboarding command. |
+| `tfy logout` | Logout from the current session. | Do not run unless the user explicitly asks. |
+| `tfy ml download artifact` | Download a logged artifact version. | Writes files locally; confirm path/overwrite. |
+| `tfy ml download model` | Download a logged model version. | Writes files locally; confirm path/overwrite. |
+| `tfy patch` | Patch a local YAML file with a `yq` filter. | Local file mutation; review target file/output path first. |
+| `tfy patch-application` | Patch and deploy an existing application. | Deployment mutation; requires explicit user confirmation. |
+| `tfy terminate job` | Terminate a job run. | Do not execute from skills; destructive operational action. |
+| `tfy trigger job` | Trigger a job run asynchronously. | Ask before triggering; may start compute/cost. |
+| `tfy trigger workflow` | Trigger a workflow run. | Ask before triggering; may start compute/cost. |
+
+## Authentication
+
+### `tfy login`
 
 Authenticate the CLI against a TrueFoundry tenant.
 
 ```bash
-# Interactive (opens browser for device code flow) — recommended
+# Interactive login
 tfy login --host https://your-org.truefoundry.cloud
 
-# Non-interactive (CI/CD only — key appears in shell history)
+# Non-interactive login
 tfy login --host https://your-org.truefoundry.cloud --api-key "$TFY_API_KEY"
 ```
 
-Stores credentials in `~/.truefoundry/credentials.json`.
+Options:
+- `--host TEXT` - required tenant URL; can be set with `TFY_HOST`.
+- `--api-key TEXT` / `--api_key TEXT` - API key for non-interactive login.
+- `--relogin` - force relogin.
+- `--help` / `-h` - show command help.
 
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--host` | Yes | Tenant URL (e.g. `https://acme.truefoundry.cloud`) |
-| `--api-key` | No | API key for non-interactive login (CI/CD) |
+After `tfy login`, credentials are stored in:
 
-### tfy apply
-
-Create or update resources from YAML manifests.
-
-```bash
-# Single file
-tfy apply -f manifest.yaml
-
-# Multiple files
-tfy apply -f manifest1.yaml -f manifest2.yaml
-
-# Entire directory (recursive, discovers *.yaml and *.yml)
-tfy apply --dir ./manifests
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) to apply. Repeatable. |
-| `--dir <path>` | Directory of manifests (cannot combine with `-f`) |
-| `--dry-run` | Simulate changes without persisting |
-| `--show-diff` | Show diff between manifest and deployed state |
-| `--diffs-only` | Apply only changed files vs HEAD (requires `--dir`) |
-| `--ref <ref>` | Git ref to diff against (default: HEAD). Use with `--diffs-only` |
-| `--sync` | Delete platform resources for removed YAML files (requires `--dir` + `--diffs-only`) |
-
-**Supported resource types:** provider-account, gateway-load-balancing-config, gateway-rate-limiting-config, gateway-budget-config, gateway-guardrails-config, mcp-server, workspace, cluster, application, secret-group, ml-repo, agent, agent-skill
-
-**Environment:** Requires `TFY_HOST` to be set when `TFY_API_KEY` is in the environment:
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
-```
-
-### tfy delete
-
-Delete resources using the same manifest files used with `tfy apply`.
-
-```bash
-# Single file
-tfy delete -f manifest.yaml
-
-# Multiple files
-tfy delete -f manifest1.yaml -f manifest2.yaml
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) identifying resources to delete. Repeatable. |
-
-### tfy --version
-
-Print the installed CLI version.
-
-```bash
-tfy --version
-# Output: tfy version X.Y.Z
-```
-
-## Commands That DO NOT Exist
-
-The following are **not valid** `tfy` subcommands. Do not attempt them:
-
-- `tfy get` / `tfy list` / `tfy describe`
-- `tfy config` / `tfy config get` / `tfy config set`
-- `tfy whoami` / `tfy status`
-- `tfy download` / `tfy upload`
-- `tfy init` / `tfy create`
-- `tfy logs` / `tfy exec`
-
-For all read/query operations, use the REST API directly via `tfy-api.sh` or `curl`.
-
-## Authentication Modes
-
-| Mode | How | When |
-|------|-----|------|
-| Interactive login | `tfy login --host <url>` | Local development |
-| Environment variables | `TFY_HOST` + `TFY_API_KEY` | CI/CD, scripts, `tfy-api.sh` |
-| Non-interactive login | `tfy login --host <url> --api-key <key>` | CI/CD (key in history — prefer env vars) |
-
-## Credential Storage
-
-After `tfy login`, credentials are stored at:
-```
+```text
 ~/.truefoundry/credentials.json
 ```
 
-Fields: `host`, `access_token`, `refresh_token`.
+Fields include `host`, `access_token`, and `refresh_token`.
+
+### `tfy logout`
+
+Logout from the current TrueFoundry session.
+
+```bash
+tfy logout
+```
+
+Do not run this unless the user explicitly asks to logout.
+
+## Apply And Deploy
+
+### `tfy apply`
+
+Create or update resources from manifest files.
+
+```bash
+tfy apply -f manifest.yaml
+tfy apply -f manifest1.yaml -f manifest2.yaml
+tfy apply -f manifest.yaml --dry-run --show-diff
+```
+
+Options:
+- `--file FILE` / `-f FILE` - required manifest file. Repeat for multiple files.
+- `--dry-run` / `--dry_run` - simulate without applying.
+- `--show-diff` / `--show_diff` - print manifest differences when using `--dry-run`.
+- `--help` / `-h` - show command help.
+
+Before the final non-dry-run apply, show the target host/workspace, an English summary, the YAML or diff, the exact command, and wait for explicit user confirmation.
+
+### `tfy deploy`
+
+Deploy an application to TrueFoundry.
+
+```bash
+tfy deploy -f truefoundry.yaml -w "<workspace-fqn>"
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to `truefoundry.yaml`.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - workspace FQN. If omitted, the CLI reads it from the deployment spec when available.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--force` / `--no-force` - cancel ongoing deployments and force a new one. Defaults to no-force.
+- `--trigger-on-deploy` / `--trigger_on_deploy` / `--no-trigger-on-deploy` / `--no_trigger_on_deploy` - trigger a job run after deployment succeeds. No effect for non-job deployments.
+- `--help` / `-h` - show command help.
+
+Always confirm the workspace before deployment. Treat `--force` and trigger-on-deploy as higher-risk options requiring explicit user confirmation.
+
+### `tfy deploy workflow`
+
+Deploy a workflow file.
+
+```bash
+tfy deploy workflow --name "<workflow-name>" -f workflow.py -w "<workspace-fqn>"
+```
+
+Options:
+- `--name TEXT` / `-n TEXT` - required workflow name.
+- `--file FILE` / `-f FILE` - required workflow file.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - required workspace FQN.
+- `--help` / `-h` - show command help.
+
+### `tfy deploy-init model`
+
+Generate application code for a model server deployment.
+
+```bash
+tfy deploy-init model \
+  --name "<application-name>" \
+  --model-version-fqn "<model-version-fqn>" \
+  --workspace-fqn "<workspace-fqn>" \
+  --model-server fastapi \
+  --output-dir ./model-server
+```
+
+Options:
+- `--name APPLICATION-NAME` - required model server deployment name.
+- `--model-version-fqn NON-EMPTY-STRING` / `--model_version_fqn` - required model version FQN.
+- `--workspace-fqn NON-EMPTY-STRING` / `--workspace_fqn` / `-w` - required workspace FQN.
+- `--model-server [triton|fastapi]` / `--model_server` - model server type. Defaults to `fastapi`.
+- `--output-dir DIRECTORY` / `--output_dir` - output directory for generated code.
+- `--help` / `-h` - show command help.
+
+## Local Patching
+
+### `tfy patch`
+
+Patch a local YAML file with a `yq` filter.
+
+```bash
+tfy patch -f servicefoundry.yaml --filter '.image.image_uri = "repo/image:tag"' -o patched.yaml
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to servicefoundry YAML. Defaults to `./servicefoundry.yaml`.
+- `--filter TEXT` - required `yq` filter.
+- `--output-file PATH` / `-o PATH` - write output to a file.
+- `--indent INTEGER` / `-I INTEGER` - output indent. Defaults to `4`.
+- `--help` / `-h` - show command help.
+
+### `tfy patch-application`
+
+Patch and deploy an existing application.
+
+```bash
+tfy patch-application --application-fqn "<application-fqn>" --patch-file patch.yaml
+tfy patch-application --application-fqn "<application-fqn>" --patch '{"key":"value"}'
+```
+
+Options:
+- `--patch-file FILE` / `--patch_file FILE` / `-f FILE` - YAML patch file.
+- `--patch TEXT` / `-p TEXT` - JSON patch string.
+- `--application-fqn TEXT` / `--application_fqn TEXT` / `-a TEXT` - required application FQN.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--help` / `-h` - show command help.
+
+This mutates a live application. Show the patch and wait for explicit user confirmation before running.
+
+## Read-Style Commands
+
+### `tfy get kubeconfig`
+
+Update kubeconfig to access a cluster attached to the TrueFoundry Control Plane.
+
+```bash
+tfy get kubeconfig --cluster "<cluster-id>" --overwrite
+```
+
+Options:
+- `--cluster TEXT` / `-c TEXT` - cluster ID. If omitted, the CLI opens an interactive cluster picker.
+- `--overwrite` - overwrite an existing cluster entry without prompting.
+- `--help` / `-h` - show command help.
+
+This writes to `~/.kube/config` by default, or to the first path in `KUBECONFIG`.
+
+## Triggering Work
+
+### `tfy trigger job`
+
+Trigger a job asynchronously.
+
+```bash
+tfy trigger job --application-fqn "<cluster:workspace:job>"
+tfy trigger job --application-fqn "<cluster:workspace:job>" --command "python run.py"
+tfy trigger job --application-fqn "<cluster:workspace:job>" -- --param value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required job deployment FQN.
+- `--command TEXT` - command to run.
+- `--run-name-alias TEXT` / `--run_name_alias TEXT` - alias for the job run name.
+- `--help` / `-h` - show command help.
+
+Ask before triggering jobs because it can start compute and cost.
+
+### `tfy trigger workflow`
+
+Trigger a workflow.
+
+```bash
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>"
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>" -- --input value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required workflow application FQN.
+- `--help` / `-h` - show command help.
+
+Ask before triggering workflows because it can start compute and cost.
+
+## ML Downloads
+
+### `tfy ml download artifact`
+
+Download a logged artifact version.
+
+```bash
+tfy ml download artifact --fqn "<artifact-version-fqn>" --path ./downloads
+```
+
+Options:
+- `--fqn TEXT` - required artifact version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+### `tfy ml download model`
+
+Download a logged model version.
+
+```bash
+tfy ml download model --fqn "<model-version-fqn>" --path ./models
+```
+
+Options:
+- `--fqn TEXT` - required model version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+## Destructive Or Blocked Commands
+
+These commands exist in the CLI but must not be executed by these skills. Provide manual dashboard instructions instead.
+
+### `tfy delete`
+
+Delete TrueFoundry resources.
+
+Observed forms:
+- `tfy delete -f manifest.yaml`
+- `tfy delete application --application-fqn "<application-fqn>"`
+- `tfy delete workspace --workspace-fqn "<workspace-fqn>"`
+
+Options:
+- `--file FILE` / `-f FILE` - manifest file(s) identifying resources to delete.
+- `tfy delete application`: `--application-fqn TEXT` / `--application_fqn TEXT`, `--yes`.
+- `tfy delete workspace`: `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT`, `--yes`.
+
+### `tfy terminate job`
+
+Terminate a job run.
+
+```bash
+tfy terminate job --job-fqn "<job-fqn>" --job-run-name "<run-name>"
+```
+
+Options:
+- `--job-fqn TEXT` / `--job_fqn TEXT` - required job FQN.
+- `--job-run-name TEXT` / `--job_run_name TEXT` - required run name.
+- `--help` / `-h` - show command help.
+
+## Commands That Do Not Exist In `tfy 0.13.12`
+
+The following are not valid `tfy` commands. Do not attempt them:
+
+- `tfy whoami`
+- `tfy show-config`
+- `tfy status`
+- `tfy config`, `tfy config get`, `tfy config set`
+- `tfy list`
+- `tfy describe`
+- `tfy logs`
+- `tfy exec`
+- `tfy init`
+- `tfy create`
+- `tfy ask`
+- top-level `tfy download` or `tfy upload` (`tfy ml download ...` is valid)
 
 ## Decision Tree
 
-```
-Need to CREATE/UPDATE/DELETE a resource?
-  → tfy apply / tfy delete
-
-Need to READ/LIST/QUERY a resource?
-  → REST API via tfy-api.sh or curl
-
+```text
 Need to verify login?
-  → Check ~/.truefoundry/credentials.json (see prerequisites.md)
+  -> Check ~/.truefoundry/credentials.json (see prerequisites.md)
+
+Need to read/list/query gateway or platform resources?
+  -> Use the REST API via tfy-api.sh or curl
+
+Need kubeconfig?
+  -> tfy get kubeconfig
+
+Need to create/update resources from manifests?
+  -> tfy apply with dry-run/diff first, then explicit user confirmation
+
+Need to deploy or patch live applications?
+  -> tfy deploy / tfy patch-application only after workspace confirmation and user approval
+
+Need to delete, terminate, revoke, remove, or purge anything?
+  -> Do not run CLI/API destructive commands; provide manual dashboard steps
 ```

--- a/skills/platform/references/prerequisites.md
+++ b/skills/platform/references/prerequisites.md
@@ -2,16 +2,10 @@
 
 ## Step 0: CLI and Login Check
 
-Check if the TrueFoundry CLI is available:
+First check if the TrueFoundry CLI is available. This tells you whether the TrueFoundry Python package and `tfy` entrypoint are installed:
 
 ```bash
 tfy --version 2>/dev/null
-```
-
-If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
-
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
 ```
 
 If not found, install it:
@@ -20,9 +14,7 @@ If not found, install it:
 pip install 'truefoundry==0.5.0'
 ```
 
-> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
-
-Before any non-onboarding skill changes TrueFoundry resources, check that CLI login already exists:
+After `tfy --version` works, check whether CLI login already exists:
 
 ```bash
 python3 - <<'PY'
@@ -44,17 +36,38 @@ else:
 PY
 ```
 
+If login is missing, say:
+
+```text
+Looks like the tenant is not set or CLI login is not done.
+If you have not already, create an account at https://www.truefoundry.com/register, complete the onboarding/signup flow, and paste your tenant URL here.
+```
+
+Then use the onboard skill to run:
+
+```bash
+tfy login --host "<tenant-url>"
+```
+
+If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
+
+```bash
+export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
+```
+
+> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
+
 If the user does not have a TrueFoundry tenant or CLI login yet, stop and use the `truefoundry-onboard` skill. Do not duplicate onboarding steps in other skills.
 
 ## CLI Command Boundaries
 
-The `tfy` CLI only supports these subcommands:
+The current CLI surface is documented in `cli-reference.md`. Do not guess commands from common CLI patterns. If a command is not in `cli-reference.md`, run `tfy --help` or `tfy <subcommand> --help` before using it.
 
-- `tfy login` — authenticate
-- `tfy apply` — apply manifests
-- `tfy --version` — version check
+Common valid commands include `tfy login`, `tfy apply`, `tfy deploy`, `tfy get kubeconfig`, `tfy trigger job`, `tfy trigger workflow`, and `tfy ml download ...`.
 
-**These do NOT exist:** `tfy get`, `tfy config`, `tfy whoami`, `tfy list`, `tfy status`, `tfy download`, `tfy upload`. Do not probe for them. For any read operation, use the REST API via `tfy-api.sh`.
+Destructive commands such as `tfy delete` and `tfy terminate job` exist, but these skills must not execute them. Provide manual dashboard instructions instead.
+
+**These do NOT exist:** `tfy config`, `tfy show-config`, `tfy whoami`, `tfy list`, `tfy status`, top-level `tfy download`, and top-level `tfy upload`. Do not probe for them. For gateway/platform read operations, use the REST API via `tfy-api.sh`.
 
 ## Credential Check
 

--- a/skills/prompts/references/cli-reference.md
+++ b/skills/prompts/references/cli-reference.md
@@ -1,6 +1,10 @@
 # TrueFoundry CLI Reference
 
-The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for querying, listing, or inspecting resources. For read operations, use the REST API via `tfy-api.sh`.
+This reference is grounded in `tfy --help` from `tfy 0.13.12`.
+
+Do not guess `tfy` subcommands from common CLI patterns. Before using any `tfy` command not shown in this file, run `tfy --help` or `tfy <subcommand> --help` and use only commands that appear in that help output.
+
+For gateway/platform read operations, prefer the REST API via `tfy-api.sh`. The CLI has `tfy get kubeconfig`, but it does not provide general list/describe/status commands for TrueFoundry resources.
 
 ## Installation
 
@@ -8,127 +12,335 @@ The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for queryi
 pip install -U "truefoundry"
 ```
 
-Requires Python 3.9–3.14. Optional extras:
-- `pip install -U "truefoundry[workflow]"` — workflow support (Python 3.9–3.12)
-- `pip install -U "truefoundry[workflow,spark]"` — workflow + Spark
+Requires Python 3.9-3.14. Optional extras:
+- `pip install -U "truefoundry[workflow]"` - workflow support (Python 3.9-3.12)
+- `pip install -U "truefoundry[workflow,spark]"` - workflow + Spark
 
-## Commands
+## Global Options
 
-### tfy login
+| Command | Purpose |
+|---|---|
+| `tfy --version` | Print the installed CLI version. |
+| `tfy --json <command>` | Output entities in JSON format where the command supports entities. |
+| `tfy --debug <command>` | Enable debug logging. Can also be set with `TFY_DEBUG=1`. |
+| `tfy --help` / `tfy -h` | Show top-level help. |
+
+## Command Index
+
+| Command | Purpose | Skill usage guidance |
+|---|---|---|
+| `tfy apply` | Create/update resources from manifest files. | Allowed only after dry-run/diff plus explicit user confirmation. |
+| `tfy delete` | Delete resources. | Do not execute from skills; provide manual dashboard instructions instead. |
+| `tfy deploy` | Deploy an application from a `truefoundry.yaml` file. | Confirm workspace before use. |
+| `tfy deploy workflow` | Deploy a workflow file. | Confirm workspace before use. |
+| `tfy deploy-init model` | Generate model server application code for a model version. | Safe scaffolding command; still confirm output path. |
+| `tfy get kubeconfig` | Update kubeconfig for a TrueFoundry cluster. | Only CLI read-style command observed. |
+| `tfy login` | Login to a TrueFoundry tenant. | Valid onboarding command. |
+| `tfy logout` | Logout from the current session. | Do not run unless the user explicitly asks. |
+| `tfy ml download artifact` | Download a logged artifact version. | Writes files locally; confirm path/overwrite. |
+| `tfy ml download model` | Download a logged model version. | Writes files locally; confirm path/overwrite. |
+| `tfy patch` | Patch a local YAML file with a `yq` filter. | Local file mutation; review target file/output path first. |
+| `tfy patch-application` | Patch and deploy an existing application. | Deployment mutation; requires explicit user confirmation. |
+| `tfy terminate job` | Terminate a job run. | Do not execute from skills; destructive operational action. |
+| `tfy trigger job` | Trigger a job run asynchronously. | Ask before triggering; may start compute/cost. |
+| `tfy trigger workflow` | Trigger a workflow run. | Ask before triggering; may start compute/cost. |
+
+## Authentication
+
+### `tfy login`
 
 Authenticate the CLI against a TrueFoundry tenant.
 
 ```bash
-# Interactive (opens browser for device code flow) — recommended
+# Interactive login
 tfy login --host https://your-org.truefoundry.cloud
 
-# Non-interactive (CI/CD only — key appears in shell history)
+# Non-interactive login
 tfy login --host https://your-org.truefoundry.cloud --api-key "$TFY_API_KEY"
 ```
 
-Stores credentials in `~/.truefoundry/credentials.json`.
+Options:
+- `--host TEXT` - required tenant URL; can be set with `TFY_HOST`.
+- `--api-key TEXT` / `--api_key TEXT` - API key for non-interactive login.
+- `--relogin` - force relogin.
+- `--help` / `-h` - show command help.
 
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--host` | Yes | Tenant URL (e.g. `https://acme.truefoundry.cloud`) |
-| `--api-key` | No | API key for non-interactive login (CI/CD) |
+After `tfy login`, credentials are stored in:
 
-### tfy apply
-
-Create or update resources from YAML manifests.
-
-```bash
-# Single file
-tfy apply -f manifest.yaml
-
-# Multiple files
-tfy apply -f manifest1.yaml -f manifest2.yaml
-
-# Entire directory (recursive, discovers *.yaml and *.yml)
-tfy apply --dir ./manifests
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) to apply. Repeatable. |
-| `--dir <path>` | Directory of manifests (cannot combine with `-f`) |
-| `--dry-run` | Simulate changes without persisting |
-| `--show-diff` | Show diff between manifest and deployed state |
-| `--diffs-only` | Apply only changed files vs HEAD (requires `--dir`) |
-| `--ref <ref>` | Git ref to diff against (default: HEAD). Use with `--diffs-only` |
-| `--sync` | Delete platform resources for removed YAML files (requires `--dir` + `--diffs-only`) |
-
-**Supported resource types:** provider-account, gateway-load-balancing-config, gateway-rate-limiting-config, gateway-budget-config, gateway-guardrails-config, mcp-server, workspace, cluster, application, secret-group, ml-repo, agent, agent-skill
-
-**Environment:** Requires `TFY_HOST` to be set when `TFY_API_KEY` is in the environment:
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
-```
-
-### tfy delete
-
-Delete resources using the same manifest files used with `tfy apply`.
-
-```bash
-# Single file
-tfy delete -f manifest.yaml
-
-# Multiple files
-tfy delete -f manifest1.yaml -f manifest2.yaml
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) identifying resources to delete. Repeatable. |
-
-### tfy --version
-
-Print the installed CLI version.
-
-```bash
-tfy --version
-# Output: tfy version X.Y.Z
-```
-
-## Commands That DO NOT Exist
-
-The following are **not valid** `tfy` subcommands. Do not attempt them:
-
-- `tfy get` / `tfy list` / `tfy describe`
-- `tfy config` / `tfy config get` / `tfy config set`
-- `tfy whoami` / `tfy status`
-- `tfy download` / `tfy upload`
-- `tfy init` / `tfy create`
-- `tfy logs` / `tfy exec`
-
-For all read/query operations, use the REST API directly via `tfy-api.sh` or `curl`.
-
-## Authentication Modes
-
-| Mode | How | When |
-|------|-----|------|
-| Interactive login | `tfy login --host <url>` | Local development |
-| Environment variables | `TFY_HOST` + `TFY_API_KEY` | CI/CD, scripts, `tfy-api.sh` |
-| Non-interactive login | `tfy login --host <url> --api-key <key>` | CI/CD (key in history — prefer env vars) |
-
-## Credential Storage
-
-After `tfy login`, credentials are stored at:
-```
+```text
 ~/.truefoundry/credentials.json
 ```
 
-Fields: `host`, `access_token`, `refresh_token`.
+Fields include `host`, `access_token`, and `refresh_token`.
+
+### `tfy logout`
+
+Logout from the current TrueFoundry session.
+
+```bash
+tfy logout
+```
+
+Do not run this unless the user explicitly asks to logout.
+
+## Apply And Deploy
+
+### `tfy apply`
+
+Create or update resources from manifest files.
+
+```bash
+tfy apply -f manifest.yaml
+tfy apply -f manifest1.yaml -f manifest2.yaml
+tfy apply -f manifest.yaml --dry-run --show-diff
+```
+
+Options:
+- `--file FILE` / `-f FILE` - required manifest file. Repeat for multiple files.
+- `--dry-run` / `--dry_run` - simulate without applying.
+- `--show-diff` / `--show_diff` - print manifest differences when using `--dry-run`.
+- `--help` / `-h` - show command help.
+
+Before the final non-dry-run apply, show the target host/workspace, an English summary, the YAML or diff, the exact command, and wait for explicit user confirmation.
+
+### `tfy deploy`
+
+Deploy an application to TrueFoundry.
+
+```bash
+tfy deploy -f truefoundry.yaml -w "<workspace-fqn>"
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to `truefoundry.yaml`.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - workspace FQN. If omitted, the CLI reads it from the deployment spec when available.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--force` / `--no-force` - cancel ongoing deployments and force a new one. Defaults to no-force.
+- `--trigger-on-deploy` / `--trigger_on_deploy` / `--no-trigger-on-deploy` / `--no_trigger_on_deploy` - trigger a job run after deployment succeeds. No effect for non-job deployments.
+- `--help` / `-h` - show command help.
+
+Always confirm the workspace before deployment. Treat `--force` and trigger-on-deploy as higher-risk options requiring explicit user confirmation.
+
+### `tfy deploy workflow`
+
+Deploy a workflow file.
+
+```bash
+tfy deploy workflow --name "<workflow-name>" -f workflow.py -w "<workspace-fqn>"
+```
+
+Options:
+- `--name TEXT` / `-n TEXT` - required workflow name.
+- `--file FILE` / `-f FILE` - required workflow file.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - required workspace FQN.
+- `--help` / `-h` - show command help.
+
+### `tfy deploy-init model`
+
+Generate application code for a model server deployment.
+
+```bash
+tfy deploy-init model \
+  --name "<application-name>" \
+  --model-version-fqn "<model-version-fqn>" \
+  --workspace-fqn "<workspace-fqn>" \
+  --model-server fastapi \
+  --output-dir ./model-server
+```
+
+Options:
+- `--name APPLICATION-NAME` - required model server deployment name.
+- `--model-version-fqn NON-EMPTY-STRING` / `--model_version_fqn` - required model version FQN.
+- `--workspace-fqn NON-EMPTY-STRING` / `--workspace_fqn` / `-w` - required workspace FQN.
+- `--model-server [triton|fastapi]` / `--model_server` - model server type. Defaults to `fastapi`.
+- `--output-dir DIRECTORY` / `--output_dir` - output directory for generated code.
+- `--help` / `-h` - show command help.
+
+## Local Patching
+
+### `tfy patch`
+
+Patch a local YAML file with a `yq` filter.
+
+```bash
+tfy patch -f servicefoundry.yaml --filter '.image.image_uri = "repo/image:tag"' -o patched.yaml
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to servicefoundry YAML. Defaults to `./servicefoundry.yaml`.
+- `--filter TEXT` - required `yq` filter.
+- `--output-file PATH` / `-o PATH` - write output to a file.
+- `--indent INTEGER` / `-I INTEGER` - output indent. Defaults to `4`.
+- `--help` / `-h` - show command help.
+
+### `tfy patch-application`
+
+Patch and deploy an existing application.
+
+```bash
+tfy patch-application --application-fqn "<application-fqn>" --patch-file patch.yaml
+tfy patch-application --application-fqn "<application-fqn>" --patch '{"key":"value"}'
+```
+
+Options:
+- `--patch-file FILE` / `--patch_file FILE` / `-f FILE` - YAML patch file.
+- `--patch TEXT` / `-p TEXT` - JSON patch string.
+- `--application-fqn TEXT` / `--application_fqn TEXT` / `-a TEXT` - required application FQN.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--help` / `-h` - show command help.
+
+This mutates a live application. Show the patch and wait for explicit user confirmation before running.
+
+## Read-Style Commands
+
+### `tfy get kubeconfig`
+
+Update kubeconfig to access a cluster attached to the TrueFoundry Control Plane.
+
+```bash
+tfy get kubeconfig --cluster "<cluster-id>" --overwrite
+```
+
+Options:
+- `--cluster TEXT` / `-c TEXT` - cluster ID. If omitted, the CLI opens an interactive cluster picker.
+- `--overwrite` - overwrite an existing cluster entry without prompting.
+- `--help` / `-h` - show command help.
+
+This writes to `~/.kube/config` by default, or to the first path in `KUBECONFIG`.
+
+## Triggering Work
+
+### `tfy trigger job`
+
+Trigger a job asynchronously.
+
+```bash
+tfy trigger job --application-fqn "<cluster:workspace:job>"
+tfy trigger job --application-fqn "<cluster:workspace:job>" --command "python run.py"
+tfy trigger job --application-fqn "<cluster:workspace:job>" -- --param value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required job deployment FQN.
+- `--command TEXT` - command to run.
+- `--run-name-alias TEXT` / `--run_name_alias TEXT` - alias for the job run name.
+- `--help` / `-h` - show command help.
+
+Ask before triggering jobs because it can start compute and cost.
+
+### `tfy trigger workflow`
+
+Trigger a workflow.
+
+```bash
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>"
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>" -- --input value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required workflow application FQN.
+- `--help` / `-h` - show command help.
+
+Ask before triggering workflows because it can start compute and cost.
+
+## ML Downloads
+
+### `tfy ml download artifact`
+
+Download a logged artifact version.
+
+```bash
+tfy ml download artifact --fqn "<artifact-version-fqn>" --path ./downloads
+```
+
+Options:
+- `--fqn TEXT` - required artifact version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+### `tfy ml download model`
+
+Download a logged model version.
+
+```bash
+tfy ml download model --fqn "<model-version-fqn>" --path ./models
+```
+
+Options:
+- `--fqn TEXT` - required model version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+## Destructive Or Blocked Commands
+
+These commands exist in the CLI but must not be executed by these skills. Provide manual dashboard instructions instead.
+
+### `tfy delete`
+
+Delete TrueFoundry resources.
+
+Observed forms:
+- `tfy delete -f manifest.yaml`
+- `tfy delete application --application-fqn "<application-fqn>"`
+- `tfy delete workspace --workspace-fqn "<workspace-fqn>"`
+
+Options:
+- `--file FILE` / `-f FILE` - manifest file(s) identifying resources to delete.
+- `tfy delete application`: `--application-fqn TEXT` / `--application_fqn TEXT`, `--yes`.
+- `tfy delete workspace`: `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT`, `--yes`.
+
+### `tfy terminate job`
+
+Terminate a job run.
+
+```bash
+tfy terminate job --job-fqn "<job-fqn>" --job-run-name "<run-name>"
+```
+
+Options:
+- `--job-fqn TEXT` / `--job_fqn TEXT` - required job FQN.
+- `--job-run-name TEXT` / `--job_run_name TEXT` - required run name.
+- `--help` / `-h` - show command help.
+
+## Commands That Do Not Exist In `tfy 0.13.12`
+
+The following are not valid `tfy` commands. Do not attempt them:
+
+- `tfy whoami`
+- `tfy show-config`
+- `tfy status`
+- `tfy config`, `tfy config get`, `tfy config set`
+- `tfy list`
+- `tfy describe`
+- `tfy logs`
+- `tfy exec`
+- `tfy init`
+- `tfy create`
+- `tfy ask`
+- top-level `tfy download` or `tfy upload` (`tfy ml download ...` is valid)
 
 ## Decision Tree
 
-```
-Need to CREATE/UPDATE/DELETE a resource?
-  → tfy apply / tfy delete
-
-Need to READ/LIST/QUERY a resource?
-  → REST API via tfy-api.sh or curl
-
+```text
 Need to verify login?
-  → Check ~/.truefoundry/credentials.json (see prerequisites.md)
+  -> Check ~/.truefoundry/credentials.json (see prerequisites.md)
+
+Need to read/list/query gateway or platform resources?
+  -> Use the REST API via tfy-api.sh or curl
+
+Need kubeconfig?
+  -> tfy get kubeconfig
+
+Need to create/update resources from manifests?
+  -> tfy apply with dry-run/diff first, then explicit user confirmation
+
+Need to deploy or patch live applications?
+  -> tfy deploy / tfy patch-application only after workspace confirmation and user approval
+
+Need to delete, terminate, revoke, remove, or purge anything?
+  -> Do not run CLI/API destructive commands; provide manual dashboard steps
 ```

--- a/skills/prompts/references/prerequisites.md
+++ b/skills/prompts/references/prerequisites.md
@@ -2,16 +2,10 @@
 
 ## Step 0: CLI and Login Check
 
-Check if the TrueFoundry CLI is available:
+First check if the TrueFoundry CLI is available. This tells you whether the TrueFoundry Python package and `tfy` entrypoint are installed:
 
 ```bash
 tfy --version 2>/dev/null
-```
-
-If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
-
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
 ```
 
 If not found, install it:
@@ -20,9 +14,7 @@ If not found, install it:
 pip install 'truefoundry==0.5.0'
 ```
 
-> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
-
-Before any non-onboarding skill changes TrueFoundry resources, check that CLI login already exists:
+After `tfy --version` works, check whether CLI login already exists:
 
 ```bash
 python3 - <<'PY'
@@ -44,17 +36,38 @@ else:
 PY
 ```
 
+If login is missing, say:
+
+```text
+Looks like the tenant is not set or CLI login is not done.
+If you have not already, create an account at https://www.truefoundry.com/register, complete the onboarding/signup flow, and paste your tenant URL here.
+```
+
+Then use the onboard skill to run:
+
+```bash
+tfy login --host "<tenant-url>"
+```
+
+If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
+
+```bash
+export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
+```
+
+> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
+
 If the user does not have a TrueFoundry tenant or CLI login yet, stop and use the `truefoundry-onboard` skill. Do not duplicate onboarding steps in other skills.
 
 ## CLI Command Boundaries
 
-The `tfy` CLI only supports these subcommands:
+The current CLI surface is documented in `cli-reference.md`. Do not guess commands from common CLI patterns. If a command is not in `cli-reference.md`, run `tfy --help` or `tfy <subcommand> --help` before using it.
 
-- `tfy login` — authenticate
-- `tfy apply` — apply manifests
-- `tfy --version` — version check
+Common valid commands include `tfy login`, `tfy apply`, `tfy deploy`, `tfy get kubeconfig`, `tfy trigger job`, `tfy trigger workflow`, and `tfy ml download ...`.
 
-**These do NOT exist:** `tfy get`, `tfy config`, `tfy whoami`, `tfy list`, `tfy status`, `tfy download`, `tfy upload`. Do not probe for them. For any read operation, use the REST API via `tfy-api.sh`.
+Destructive commands such as `tfy delete` and `tfy terminate job` exist, but these skills must not execute them. Provide manual dashboard instructions instead.
+
+**These do NOT exist:** `tfy config`, `tfy show-config`, `tfy whoami`, `tfy list`, `tfy status`, top-level `tfy download`, and top-level `tfy upload`. Do not probe for them. For gateway/platform read operations, use the REST API via `tfy-api.sh`.
 
 ## Credential Check
 

--- a/skills/skills-registry/SKILL.md
+++ b/skills/skills-registry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: truefoundry-skills-registry
-description: Manages TrueFoundry Skills Registry workflows. Covers creating, publishing, versioning, downloading, updating, and attaching reusable Agent Skills through UI, tfy upload skill, or tfy apply.
+description: Manages TrueFoundry Skills Registry workflows. Covers creating, publishing, versioning, downloading, updating, and attaching reusable Agent Skills through UI or tfy apply.
 license: MIT
 compatibility: Requires Bash, tfy CLI, and access to a TrueFoundry tenant
 allowed-tools: Bash(tfy*) Bash(python*) Bash(find*) Bash(rg*)
@@ -32,8 +32,8 @@ Use this skill when the user wants to:
 2. Confirm the target tenant and repository.
 3. Decide the publish path:
    - UI: single-file `SKILL.md`.
-   - `tfy upload skill`: multi-file skill bundles.
-   - `tfy apply`: declarative/GitOps flow.
+   - `tfy apply`: declarative/GitOps flow when an `agent-skill` manifest is available.
+   - Multi-file bundles: use the dashboard/registry workflow or exact product-provided command only after verifying it exists in `tfy --help`.
 
 ## UI Path
 
@@ -54,7 +54,7 @@ Required fields:
 
 To create a new version later, open the skill and click `New Version`.
 
-## CLI Upload
+## Multi-File Bundles
 
 Use this for multi-file skills with `references/`, `scripts/`, or `assets/`.
 
@@ -68,19 +68,15 @@ my-skill/
   assets/
 ```
 
-Publish:
-
-```bash
-tfy upload skill --dir ./my-skill
-```
-
 Before upload, inspect:
 
 ```bash
 find ./my-skill -maxdepth 3 -type f | sort
 ```
 
-Show the user the file list and ask for confirmation before upload.
+Show the user the file list and ask for confirmation before publishing.
+
+Do not run `tfy upload skill`; it is not present in `tfy 0.13.12`. If the product UI shows a generated command in the future, verify it with `tfy --help` before using it.
 
 ## Declarative Apply
 
@@ -95,11 +91,7 @@ Then ask for explicit confirmation.
 
 ## Download Existing Skill
 
-Use the Usage tab in the Skill Detail page to copy the exact command, or use:
-
-```bash
-tfy download skill --fqn <skill-fqn> --dir ./skills
-```
+Use the Usage tab in the Skill Detail page or the dashboard export/download flow.
 
 After download, inspect the files before editing.
 
@@ -118,7 +110,7 @@ Use `truefoundry-agents` for the agent-side flow.
 - Skills live inside a Repository.
 - Repository RBAC controls who can discover, use, and publish skill versions.
 - Skills can be pinned by version when attached to agents.
-- UI upload currently supports single-file `SKILL.md`; multi-file skills should use CLI upload or apply.
+- UI upload currently supports single-file `SKILL.md`; multi-file skills should use the dashboard/registry workflow or declarative apply when a manifest is available.
 
 ## Delete
 
@@ -128,10 +120,10 @@ Do not delete skills from the agent. If deletion is requested, direct the user t
 
 <success_criteria>
 
-- The user knows whether UI, upload, or apply is the right publish path.
+- The user knows whether UI, dashboard/registry workflow, or apply is the right publish path.
 - Single-file and multi-file skill flows are clearly separated.
 - New versions are created intentionally.
 - Skill attachment is routed through Agent Playground.
-- Final upload/apply is confirmed before execution.
+- Final publish/apply is confirmed before execution.
 
 </success_criteria>

--- a/skills/skills-registry/references/cli-reference.md
+++ b/skills/skills-registry/references/cli-reference.md
@@ -1,6 +1,10 @@
 # TrueFoundry CLI Reference
 
-The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for querying, listing, or inspecting resources. For read operations, use the REST API via `tfy-api.sh`.
+This reference is grounded in `tfy --help` from `tfy 0.13.12`.
+
+Do not guess `tfy` subcommands from common CLI patterns. Before using any `tfy` command not shown in this file, run `tfy --help` or `tfy <subcommand> --help` and use only commands that appear in that help output.
+
+For gateway/platform read operations, prefer the REST API via `tfy-api.sh`. The CLI has `tfy get kubeconfig`, but it does not provide general list/describe/status commands for TrueFoundry resources.
 
 ## Installation
 
@@ -8,127 +12,335 @@ The `tfy` CLI is a thin deployment tool. It does NOT have subcommands for queryi
 pip install -U "truefoundry"
 ```
 
-Requires Python 3.9–3.14. Optional extras:
-- `pip install -U "truefoundry[workflow]"` — workflow support (Python 3.9–3.12)
-- `pip install -U "truefoundry[workflow,spark]"` — workflow + Spark
+Requires Python 3.9-3.14. Optional extras:
+- `pip install -U "truefoundry[workflow]"` - workflow support (Python 3.9-3.12)
+- `pip install -U "truefoundry[workflow,spark]"` - workflow + Spark
 
-## Commands
+## Global Options
 
-### tfy login
+| Command | Purpose |
+|---|---|
+| `tfy --version` | Print the installed CLI version. |
+| `tfy --json <command>` | Output entities in JSON format where the command supports entities. |
+| `tfy --debug <command>` | Enable debug logging. Can also be set with `TFY_DEBUG=1`. |
+| `tfy --help` / `tfy -h` | Show top-level help. |
+
+## Command Index
+
+| Command | Purpose | Skill usage guidance |
+|---|---|---|
+| `tfy apply` | Create/update resources from manifest files. | Allowed only after dry-run/diff plus explicit user confirmation. |
+| `tfy delete` | Delete resources. | Do not execute from skills; provide manual dashboard instructions instead. |
+| `tfy deploy` | Deploy an application from a `truefoundry.yaml` file. | Confirm workspace before use. |
+| `tfy deploy workflow` | Deploy a workflow file. | Confirm workspace before use. |
+| `tfy deploy-init model` | Generate model server application code for a model version. | Safe scaffolding command; still confirm output path. |
+| `tfy get kubeconfig` | Update kubeconfig for a TrueFoundry cluster. | Only CLI read-style command observed. |
+| `tfy login` | Login to a TrueFoundry tenant. | Valid onboarding command. |
+| `tfy logout` | Logout from the current session. | Do not run unless the user explicitly asks. |
+| `tfy ml download artifact` | Download a logged artifact version. | Writes files locally; confirm path/overwrite. |
+| `tfy ml download model` | Download a logged model version. | Writes files locally; confirm path/overwrite. |
+| `tfy patch` | Patch a local YAML file with a `yq` filter. | Local file mutation; review target file/output path first. |
+| `tfy patch-application` | Patch and deploy an existing application. | Deployment mutation; requires explicit user confirmation. |
+| `tfy terminate job` | Terminate a job run. | Do not execute from skills; destructive operational action. |
+| `tfy trigger job` | Trigger a job run asynchronously. | Ask before triggering; may start compute/cost. |
+| `tfy trigger workflow` | Trigger a workflow run. | Ask before triggering; may start compute/cost. |
+
+## Authentication
+
+### `tfy login`
 
 Authenticate the CLI against a TrueFoundry tenant.
 
 ```bash
-# Interactive (opens browser for device code flow) — recommended
+# Interactive login
 tfy login --host https://your-org.truefoundry.cloud
 
-# Non-interactive (CI/CD only — key appears in shell history)
+# Non-interactive login
 tfy login --host https://your-org.truefoundry.cloud --api-key "$TFY_API_KEY"
 ```
 
-Stores credentials in `~/.truefoundry/credentials.json`.
+Options:
+- `--host TEXT` - required tenant URL; can be set with `TFY_HOST`.
+- `--api-key TEXT` / `--api_key TEXT` - API key for non-interactive login.
+- `--relogin` - force relogin.
+- `--help` / `-h` - show command help.
 
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--host` | Yes | Tenant URL (e.g. `https://acme.truefoundry.cloud`) |
-| `--api-key` | No | API key for non-interactive login (CI/CD) |
+After `tfy login`, credentials are stored in:
 
-### tfy apply
-
-Create or update resources from YAML manifests.
-
-```bash
-# Single file
-tfy apply -f manifest.yaml
-
-# Multiple files
-tfy apply -f manifest1.yaml -f manifest2.yaml
-
-# Entire directory (recursive, discovers *.yaml and *.yml)
-tfy apply --dir ./manifests
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) to apply. Repeatable. |
-| `--dir <path>` | Directory of manifests (cannot combine with `-f`) |
-| `--dry-run` | Simulate changes without persisting |
-| `--show-diff` | Show diff between manifest and deployed state |
-| `--diffs-only` | Apply only changed files vs HEAD (requires `--dir`) |
-| `--ref <ref>` | Git ref to diff against (default: HEAD). Use with `--diffs-only` |
-| `--sync` | Delete platform resources for removed YAML files (requires `--dir` + `--diffs-only`) |
-
-**Supported resource types:** provider-account, gateway-load-balancing-config, gateway-rate-limiting-config, gateway-budget-config, gateway-guardrails-config, mcp-server, workspace, cluster, application, secret-group, ml-repo, agent, agent-skill
-
-**Environment:** Requires `TFY_HOST` to be set when `TFY_API_KEY` is in the environment:
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
-```
-
-### tfy delete
-
-Delete resources using the same manifest files used with `tfy apply`.
-
-```bash
-# Single file
-tfy delete -f manifest.yaml
-
-# Multiple files
-tfy delete -f manifest1.yaml -f manifest2.yaml
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f <file>` | Manifest file(s) identifying resources to delete. Repeatable. |
-
-### tfy --version
-
-Print the installed CLI version.
-
-```bash
-tfy --version
-# Output: tfy version X.Y.Z
-```
-
-## Commands That DO NOT Exist
-
-The following are **not valid** `tfy` subcommands. Do not attempt them:
-
-- `tfy get` / `tfy list` / `tfy describe`
-- `tfy config` / `tfy config get` / `tfy config set`
-- `tfy whoami` / `tfy status`
-- `tfy download` / `tfy upload`
-- `tfy init` / `tfy create`
-- `tfy logs` / `tfy exec`
-
-For all read/query operations, use the REST API directly via `tfy-api.sh` or `curl`.
-
-## Authentication Modes
-
-| Mode | How | When |
-|------|-----|------|
-| Interactive login | `tfy login --host <url>` | Local development |
-| Environment variables | `TFY_HOST` + `TFY_API_KEY` | CI/CD, scripts, `tfy-api.sh` |
-| Non-interactive login | `tfy login --host <url> --api-key <key>` | CI/CD (key in history — prefer env vars) |
-
-## Credential Storage
-
-After `tfy login`, credentials are stored at:
-```
+```text
 ~/.truefoundry/credentials.json
 ```
 
-Fields: `host`, `access_token`, `refresh_token`.
+Fields include `host`, `access_token`, and `refresh_token`.
+
+### `tfy logout`
+
+Logout from the current TrueFoundry session.
+
+```bash
+tfy logout
+```
+
+Do not run this unless the user explicitly asks to logout.
+
+## Apply And Deploy
+
+### `tfy apply`
+
+Create or update resources from manifest files.
+
+```bash
+tfy apply -f manifest.yaml
+tfy apply -f manifest1.yaml -f manifest2.yaml
+tfy apply -f manifest.yaml --dry-run --show-diff
+```
+
+Options:
+- `--file FILE` / `-f FILE` - required manifest file. Repeat for multiple files.
+- `--dry-run` / `--dry_run` - simulate without applying.
+- `--show-diff` / `--show_diff` - print manifest differences when using `--dry-run`.
+- `--help` / `-h` - show command help.
+
+Before the final non-dry-run apply, show the target host/workspace, an English summary, the YAML or diff, the exact command, and wait for explicit user confirmation.
+
+### `tfy deploy`
+
+Deploy an application to TrueFoundry.
+
+```bash
+tfy deploy -f truefoundry.yaml -w "<workspace-fqn>"
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to `truefoundry.yaml`.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - workspace FQN. If omitted, the CLI reads it from the deployment spec when available.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--force` / `--no-force` - cancel ongoing deployments and force a new one. Defaults to no-force.
+- `--trigger-on-deploy` / `--trigger_on_deploy` / `--no-trigger-on-deploy` / `--no_trigger_on_deploy` - trigger a job run after deployment succeeds. No effect for non-job deployments.
+- `--help` / `-h` - show command help.
+
+Always confirm the workspace before deployment. Treat `--force` and trigger-on-deploy as higher-risk options requiring explicit user confirmation.
+
+### `tfy deploy workflow`
+
+Deploy a workflow file.
+
+```bash
+tfy deploy workflow --name "<workflow-name>" -f workflow.py -w "<workspace-fqn>"
+```
+
+Options:
+- `--name TEXT` / `-n TEXT` - required workflow name.
+- `--file FILE` / `-f FILE` - required workflow file.
+- `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT` - required workspace FQN.
+- `--help` / `-h` - show command help.
+
+### `tfy deploy-init model`
+
+Generate application code for a model server deployment.
+
+```bash
+tfy deploy-init model \
+  --name "<application-name>" \
+  --model-version-fqn "<model-version-fqn>" \
+  --workspace-fqn "<workspace-fqn>" \
+  --model-server fastapi \
+  --output-dir ./model-server
+```
+
+Options:
+- `--name APPLICATION-NAME` - required model server deployment name.
+- `--model-version-fqn NON-EMPTY-STRING` / `--model_version_fqn` - required model version FQN.
+- `--workspace-fqn NON-EMPTY-STRING` / `--workspace_fqn` / `-w` - required workspace FQN.
+- `--model-server [triton|fastapi]` / `--model_server` - model server type. Defaults to `fastapi`.
+- `--output-dir DIRECTORY` / `--output_dir` - output directory for generated code.
+- `--help` / `-h` - show command help.
+
+## Local Patching
+
+### `tfy patch`
+
+Patch a local YAML file with a `yq` filter.
+
+```bash
+tfy patch -f servicefoundry.yaml --filter '.image.image_uri = "repo/image:tag"' -o patched.yaml
+```
+
+Options:
+- `--file FILE` / `-f FILE` - path to servicefoundry YAML. Defaults to `./servicefoundry.yaml`.
+- `--filter TEXT` - required `yq` filter.
+- `--output-file PATH` / `-o PATH` - write output to a file.
+- `--indent INTEGER` / `-I INTEGER` - output indent. Defaults to `4`.
+- `--help` / `-h` - show command help.
+
+### `tfy patch-application`
+
+Patch and deploy an existing application.
+
+```bash
+tfy patch-application --application-fqn "<application-fqn>" --patch-file patch.yaml
+tfy patch-application --application-fqn "<application-fqn>" --patch '{"key":"value"}'
+```
+
+Options:
+- `--patch-file FILE` / `--patch_file FILE` / `-f FILE` - YAML patch file.
+- `--patch TEXT` / `-p TEXT` - JSON patch string.
+- `--application-fqn TEXT` / `--application_fqn TEXT` / `-a TEXT` - required application FQN.
+- `--wait` / `--no-wait` / `--no_wait` - wait and tail deployment progress. Defaults to wait.
+- `--help` / `-h` - show command help.
+
+This mutates a live application. Show the patch and wait for explicit user confirmation before running.
+
+## Read-Style Commands
+
+### `tfy get kubeconfig`
+
+Update kubeconfig to access a cluster attached to the TrueFoundry Control Plane.
+
+```bash
+tfy get kubeconfig --cluster "<cluster-id>" --overwrite
+```
+
+Options:
+- `--cluster TEXT` / `-c TEXT` - cluster ID. If omitted, the CLI opens an interactive cluster picker.
+- `--overwrite` - overwrite an existing cluster entry without prompting.
+- `--help` / `-h` - show command help.
+
+This writes to `~/.kube/config` by default, or to the first path in `KUBECONFIG`.
+
+## Triggering Work
+
+### `tfy trigger job`
+
+Trigger a job asynchronously.
+
+```bash
+tfy trigger job --application-fqn "<cluster:workspace:job>"
+tfy trigger job --application-fqn "<cluster:workspace:job>" --command "python run.py"
+tfy trigger job --application-fqn "<cluster:workspace:job>" -- --param value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required job deployment FQN.
+- `--command TEXT` - command to run.
+- `--run-name-alias TEXT` / `--run_name_alias TEXT` - alias for the job run name.
+- `--help` / `-h` - show command help.
+
+Ask before triggering jobs because it can start compute and cost.
+
+### `tfy trigger workflow`
+
+Trigger a workflow.
+
+```bash
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>"
+tfy trigger workflow --application-fqn "<cluster:workspace:workflow>" -- --input value
+```
+
+Options:
+- `--application-fqn TEXT` / `--application_fqn TEXT` - required workflow application FQN.
+- `--help` / `-h` - show command help.
+
+Ask before triggering workflows because it can start compute and cost.
+
+## ML Downloads
+
+### `tfy ml download artifact`
+
+Download a logged artifact version.
+
+```bash
+tfy ml download artifact --fqn "<artifact-version-fqn>" --path ./downloads
+```
+
+Options:
+- `--fqn TEXT` - required artifact version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+### `tfy ml download model`
+
+Download a logged model version.
+
+```bash
+tfy ml download model --fqn "<model-version-fqn>" --path ./models
+```
+
+Options:
+- `--fqn TEXT` - required model version FQN.
+- `--path DIRECTORY` - download destination. Defaults to `./`.
+- `--overwrite` - overwrite existing files in the destination.
+- `--progress` / `--no-progress` - show or hide progress while downloading.
+- `--help` / `-h` - show command help.
+
+## Destructive Or Blocked Commands
+
+These commands exist in the CLI but must not be executed by these skills. Provide manual dashboard instructions instead.
+
+### `tfy delete`
+
+Delete TrueFoundry resources.
+
+Observed forms:
+- `tfy delete -f manifest.yaml`
+- `tfy delete application --application-fqn "<application-fqn>"`
+- `tfy delete workspace --workspace-fqn "<workspace-fqn>"`
+
+Options:
+- `--file FILE` / `-f FILE` - manifest file(s) identifying resources to delete.
+- `tfy delete application`: `--application-fqn TEXT` / `--application_fqn TEXT`, `--yes`.
+- `tfy delete workspace`: `--workspace-fqn TEXT` / `--workspace_fqn TEXT` / `-w TEXT`, `--yes`.
+
+### `tfy terminate job`
+
+Terminate a job run.
+
+```bash
+tfy terminate job --job-fqn "<job-fqn>" --job-run-name "<run-name>"
+```
+
+Options:
+- `--job-fqn TEXT` / `--job_fqn TEXT` - required job FQN.
+- `--job-run-name TEXT` / `--job_run_name TEXT` - required run name.
+- `--help` / `-h` - show command help.
+
+## Commands That Do Not Exist In `tfy 0.13.12`
+
+The following are not valid `tfy` commands. Do not attempt them:
+
+- `tfy whoami`
+- `tfy show-config`
+- `tfy status`
+- `tfy config`, `tfy config get`, `tfy config set`
+- `tfy list`
+- `tfy describe`
+- `tfy logs`
+- `tfy exec`
+- `tfy init`
+- `tfy create`
+- `tfy ask`
+- top-level `tfy download` or `tfy upload` (`tfy ml download ...` is valid)
 
 ## Decision Tree
 
-```
-Need to CREATE/UPDATE/DELETE a resource?
-  → tfy apply / tfy delete
-
-Need to READ/LIST/QUERY a resource?
-  → REST API via tfy-api.sh or curl
-
+```text
 Need to verify login?
-  → Check ~/.truefoundry/credentials.json (see prerequisites.md)
+  -> Check ~/.truefoundry/credentials.json (see prerequisites.md)
+
+Need to read/list/query gateway or platform resources?
+  -> Use the REST API via tfy-api.sh or curl
+
+Need kubeconfig?
+  -> tfy get kubeconfig
+
+Need to create/update resources from manifests?
+  -> tfy apply with dry-run/diff first, then explicit user confirmation
+
+Need to deploy or patch live applications?
+  -> tfy deploy / tfy patch-application only after workspace confirmation and user approval
+
+Need to delete, terminate, revoke, remove, or purge anything?
+  -> Do not run CLI/API destructive commands; provide manual dashboard steps
 ```

--- a/skills/skills-registry/references/prerequisites.md
+++ b/skills/skills-registry/references/prerequisites.md
@@ -2,16 +2,10 @@
 
 ## Step 0: CLI and Login Check
 
-Check if the TrueFoundry CLI is available:
+First check if the TrueFoundry CLI is available. This tells you whether the TrueFoundry Python package and `tfy` entrypoint are installed:
 
 ```bash
 tfy --version 2>/dev/null
-```
-
-If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
-
-```bash
-export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
 ```
 
 If not found, install it:
@@ -20,9 +14,7 @@ If not found, install it:
 pip install 'truefoundry==0.5.0'
 ```
 
-> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
-
-Before any non-onboarding skill changes TrueFoundry resources, check that CLI login already exists:
+After `tfy --version` works, check whether CLI login already exists:
 
 ```bash
 python3 - <<'PY'
@@ -44,17 +36,38 @@ else:
 PY
 ```
 
+If login is missing, say:
+
+```text
+Looks like the tenant is not set or CLI login is not done.
+If you have not already, create an account at https://www.truefoundry.com/register, complete the onboarding/signup flow, and paste your tenant URL here.
+```
+
+Then use the onboard skill to run:
+
+```bash
+tfy login --host "<tenant-url>"
+```
+
+If `TFY_API_KEY` is set and you use `tfy` CLI commands (`tfy apply`), ensure `TFY_HOST` is set:
+
+```bash
+export TFY_HOST="${TFY_HOST:-${TFY_BASE_URL%/}}"
+```
+
+> **Note:** The CLI (`tfy apply`) is the recommended deployment method, but it is not strictly required. All skills fall back to the REST API via `tfy-api.sh` when the CLI is unavailable.
+
 If the user does not have a TrueFoundry tenant or CLI login yet, stop and use the `truefoundry-onboard` skill. Do not duplicate onboarding steps in other skills.
 
 ## CLI Command Boundaries
 
-The `tfy` CLI only supports these subcommands:
+The current CLI surface is documented in `cli-reference.md`. Do not guess commands from common CLI patterns. If a command is not in `cli-reference.md`, run `tfy --help` or `tfy <subcommand> --help` before using it.
 
-- `tfy login` — authenticate
-- `tfy apply` — apply manifests
-- `tfy --version` — version check
+Common valid commands include `tfy login`, `tfy apply`, `tfy deploy`, `tfy get kubeconfig`, `tfy trigger job`, `tfy trigger workflow`, and `tfy ml download ...`.
 
-**These do NOT exist:** `tfy get`, `tfy config`, `tfy whoami`, `tfy list`, `tfy status`, `tfy download`, `tfy upload`. Do not probe for them. For any read operation, use the REST API via `tfy-api.sh`.
+Destructive commands such as `tfy delete` and `tfy terminate job` exist, but these skills must not execute them. Provide manual dashboard instructions instead.
+
+**These do NOT exist:** `tfy config`, `tfy show-config`, `tfy whoami`, `tfy list`, `tfy status`, top-level `tfy download`, and top-level `tfy upload`. Do not probe for them. For gateway/platform read operations, use the REST API via `tfy-api.sh`.
 
 ## Credential Check
 


### PR DESCRIPTION
## Summary

- Keep the public README setup CTA as `npx skills add truefoundry/skills` plus the prompt `sign me up for truefoundry`.
- Expand `cli-reference.md` from the live `tfy 0.13.12` help surface, including valid nested commands and explicit invalid commands.
- Update onboarding/prerequisite flow to check `tfy --version` first, then verify CLI login via credentials, then guide registration and `tfy login --host <tenant-url>` when missing.
- Add `scripts/check-tfy-cli-reference.sh` and wire it into `validate-skills.sh` to catch CLI/reference drift.
- Remove nonexistent `tfy upload skill` / `tfy download skill` guidance from the skills registry flow.
- Polish launch docs: use raw install-instruction URLs, remove a stale `AGENTS.md` reference, and keep `TFY_API_KEY` optional in `.env.example`.

## Launch Flow

After this PR lands on `main`, users can run:

```bash
npx skills add truefoundry/skills
```

Then in Claude Code, Codex, or Cursor they can say:

```text
sign me up for truefoundry
```

That invokes `truefoundry-onboard`, which checks existing CLI login, sends new users to registration, collects the tenant URL, guides `tfy login --host <tenant-url>`, and stops after login verification.

## Validation

- `./scripts/validate-skills.sh`
- `./scripts/validate-skill-security.sh`
- `./scripts/test-tfy-api.sh`
- `git diff --check`
- `bash scripts/install.sh --help`
- `shellcheck scripts/*.sh hooks/auto-approve-tfy-api.sh skills/_shared/scripts/tfy-api.sh plugin-scripts/*.sh`
- `npx skills add truefoundry/skills --list`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new validation step (`check-tfy-cli-reference.sh`) that can fail CI/local validation when the installed `tfy` CLI differs from the documented surface. Functional code paths aren’t changed, but contributor workflow and docs are tightly coupled to a specific CLI version.
> 
> **Overview**
> **Keeps `tfy` command documentation in sync with reality.** Adds `scripts/check-tfy-cli-reference.sh` (wired into `scripts/validate-skills.sh` and CONTRIBUTING) to compare `tfy --help`/subcommand help against an expected subcommand list, assert documented commands expose help, and ensure explicitly *invalid* commands still fail.
> 
> **Refreshes onboarding/setup guidance and examples.** Expands `cli-reference.md` across all skills to mirror `tfy 0.13.12` (valid nested commands, global flags, and explicit “do not run” destructive commands), updates prerequisites/onboarding flow to check `tfy --version` before credential-based login verification, removes guidance for non-existent `tfy upload/download skill`, and tweaks install/setup CTAs (raw GitHub URLs, optional blank `TFY_API_KEY`, README prompt text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e719b85cc3423247689b58dfbc111db388a24fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->