### PR TITLE
Use email OTP signup in onboarding skill

### DIFF
--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -2,8 +2,8 @@
 name: truefoundry-onboard
 description: First-time TrueFoundry setup. Handles tenant registration, CLI installation, tfy login, and login verification. Use when no TrueFoundry credentials exist or when other skills report missing login.
 license: MIT
-compatibility: Requires Bash, Python 3, and the tfy CLI
-allowed-tools: Bash(tfy*) Bash(pip*) Bash(uv*) Bash(python*) Bash(cat*) Bash(mkdir*)
+compatibility: Requires Bash, Python 3, curl, and the tfy CLI
+allowed-tools: Bash(tfy*) Bash(pip*) Bash(uv*) Bash(python*) Bash(cat*) Bash(mkdir*) Bash(curl*)
 ---
 
 <objective>
@@ -81,22 +81,48 @@ PY
 
 If login is already present, tell the user the tenant host and stop. The next requested TrueFoundry skill can continue.
 
-### Step 3: Get Tenant URL If Login Is Missing
+### Step 3: Create Or Get Tenant URL If Login Is Missing
 
 If the login check prints `tfy login: missing`, say:
 
 ```text
 Looks like the tenant is not set or CLI login is not done.
-If you have not already, create an account at https://www.truefoundry.com/register, complete the onboarding/signup flow, and paste your tenant URL here.
+If you already have a TrueFoundry tenant URL, paste it here.
+If not, I can create one with email OTP from this session.
 ```
 
-Accept a full tenant URL, for example:
+If the user has a tenant URL, accept a full tenant URL, for example:
 
 ```text
 https://acme.truefoundry.cloud
 ```
 
-Use browser registration only for new tenants.
+If the user wants to create a tenant from this session:
+
+1. Ask for their email and desired tenant name.
+2. Use `https://registration.truefoundry.com` as the registration server base URL, unless `TFY_REGISTRATION_SERVER_URL` is set.
+3. Initiate OTP:
+
+```bash
+REGISTRATION_SERVER_URL="${TFY_REGISTRATION_SERVER_URL:-https://registration.truefoundry.com}"
+curl -fsS "$REGISTRATION_SERVER_URL/v1/tenant/onboarding/otp/initiate" \
+  -H "Content-Type: application/json" \
+  -H "x-truefoundry-registration-source: skills" \
+  -d '{"email":"<email>"}'
+```
+
+4. Ask the user to paste the OTP from email.
+5. Complete signup:
+
+```bash
+REGISTRATION_SERVER_URL="${TFY_REGISTRATION_SERVER_URL:-https://registration.truefoundry.com}"
+curl -fsS "$REGISTRATION_SERVER_URL/v1/tenant/onboarding/otp/complete" \
+  -H "Content-Type: application/json" \
+  -H "x-truefoundry-registration-source: skills" \
+  -d '{"email":"<email>","otp":"<otp>","tenantName":"<tenant-name>"}'
+```
+
+Use the returned `host` as the tenant URL. The `x-truefoundry-registration-source: skills` header is required so signup attribution is stored on the tenant metadata.
 
 ### Step 4: Login
 

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -116,20 +116,21 @@ curl -fsS "$REGISTRATION_SERVER_URL/v1/tenant/onboarding/otp/initiate" \
 
 ```bash
 REGISTRATION_SERVER_URL="${TFY_REGISTRATION_SERVER_URL:-https://registration.truefoundry.com}"
-curl -fsS "$REGISTRATION_SERVER_URL/v1/tenant/onboarding/otp/complete" \
+SIGNUP_RESPONSE=$(curl -fsS "$REGISTRATION_SERVER_URL/v1/tenant/onboarding/otp/complete" \
   -H "Content-Type: application/json" \
   -H "x-truefoundry-registration-source: skills" \
-  -d '{"email":"<email>","otp":"<otp>","tenantName":"<tenant-name>"}'
+  -d '{"email":"<email>","otp":"<otp>","tenantName":"<tenant-name>"}')
+TENANT_URL=$(printf '%s' "$SIGNUP_RESPONSE" | python3 -c 'import json,sys; print(json.load(sys.stdin)["host"])')
 ```
 
-Use the returned `host` as the tenant URL. The `x-truefoundry-registration-source: skills` header is required so signup attribution is stored on the tenant metadata.
+Use `TENANT_URL` as the tenant URL. The `x-truefoundry-registration-source: skills` header is required so signup attribution is stored on the tenant metadata.
 
 ### Step 4: Login
 
-After the user provides the tenant URL, ask them to complete interactive login:
+If `TENANT_URL` is already set from OTP signup, use it directly. Otherwise, after the user provides the tenant URL, ask them to complete interactive login:
 
 ```bash
-tfy login --host "<tenant-url>"
+tfy login --host "${TENANT_URL:-<tenant-url>}"
 ```
 
 The command may open a browser. Wait for the user to confirm it succeeded. This sets the CLI host and stores CLI credentials on the machine.


### PR DESCRIPTION
## Summary
- Updates the onboarding skill to support creating a tenant via email OTP from the terminal session.
- Calls the hosted registration service by default, with `TFY_REGISTRATION_SERVER_URL` as an override.
- Sends `x-truefoundry-registration-source: skills` so backend metadata records signup source.

## Scope
Only the onboarding skill instructions changed. Other skills are untouched.

## Validation
- `git diff --check`
- `./scripts/validate-skills.sh`
- `./scripts/validate-skill-security.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates onboarding instructions to perform tenant signup via terminal-based OTP using `curl`, which introduces a new external API call flow and handling of user email/OTP values. Impact is limited to the `truefoundry-onboard` skill documentation/allowed-tools, but mistakes could break onboarding or leak sensitive inputs in command history.
> 
> **Overview**
> The `truefoundry-onboard` skill now supports **creating a new TrueFoundry tenant from the session** via email OTP, in addition to accepting an existing tenant URL.
> 
> It adds `curl` as an allowed tool and documents calling the hosted registration service (overrideable via `TFY_REGISTRATION_SERVER_URL`) to initiate/complete OTP signup, extract `TENANT_URL` from the response, and then run `tfy login` using that URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 704d24887d9d516668f379ecc5aa284e84486952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->